### PR TITLE
Merge stat-scaling post-M8 hardening into master

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+* text=auto eol=lf
+
+# Source / config / docs
+*.py text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+*.ini text eol=lf
+*.cfg text eol=lf
+*.gitignore text eol=lf
+.gitattributes text eol=lf
+
+# Common binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.pdf binary

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ qodana.sarif.json
 # Local backups and archives
 backup/
 update info/
+.codex-remote-attachments/
 *.zip
 *.tar
 *.tar.gz

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 Dungeon Drifters is a text-based Python RPG prototype set in the land of Ketlyv.
 
-The current repository checkpoint is **v0.2.8**. This is the completed
-structured Goblin Battle checkpoint between **v0.2** and the unfinished
-**v0.3** release. The small Goblin vertical slice remains the playable
-baseline, now routed through structured moves, the combat resolver, and
-encounter-owned combat state.
+The current repository checkpoint is **v0.2.8.5**. This is the completed
+structured Goblin Battle checkpoint plus the first post-M8 stat-scaling and
+hardening pass between **v0.2** and the unfinished **v0.3** release. The
+playable baseline is still a small Goblin vertical slice, but it now runs
+through structured moves, the combat resolver, encounter-owned combat state,
+and the current player stat-scaling contract.
 
 ## Current Playable State
 
@@ -29,8 +30,8 @@ existing mechanical archetypes:
 - Zhaivra Kelyth, the Uncontrolled Reagent - Rogue Archer
 - Joruun Veyr, the Bloody Storm Monk - Monk
 
-Battle now uses the structured combat path for the Goblin encounter. It
-presents:
+The Goblin encounter now uses the structured combat path. The main battle menu
+currently presents:
 
 - Attack
 - Defend
@@ -39,7 +40,7 @@ presents:
 
 Attack and Super open structured move submenus sourced from the active
 Drifter's authored combat moves. Defend is a core combat action. Items are
-listed but not yet wired.
+visible but not yet wired.
 
 ## Play Instructions
 
@@ -69,19 +70,21 @@ The repository now includes these active foundations:
 - `PlayerState`, `StoryState`, and `WorldState` ownership boundaries.
 - Separated character runtime state, loadout definitions, and profile identity.
 - Canonical character profiles for the four current Drifters.
-- Per-character loadout modules for legacy move names, structured moves, and
-  identity metadata.
+- Per-character loadout modules for identity metadata, starting stats, legacy
+  move names, and structured combat moves.
 - Health, mana, level, EXP, permanent stats, and effective stat access.
+- Central player stat-scaling helpers for HP, Mana, output scaling, physical
+  negation, accuracy, dodge, Super gain, and crit chance.
 - Inventory, gold, and equipment slot state on `PlayerState`.
 - Immutable validated `Move` definitions.
-- Immutable validated `MoveResult` as the future resolution-result contract.
+- Immutable validated `MoveResult` as the structured combat result contract.
 - Shared `Combatant` protocol for player and enemy runtime state.
 - Runtime `EnemyState` with independent health, mana, stats, and structured
   enemy moves.
 - Enemy archetype metadata for rank, role, behavior, capabilities, and tier.
-- `app.combat` contains reusable combat rules and contracts; `app.enemies`
-  contains enemy definitions, runtime state, registration, scaling, factory, and
-  authored enemy content.
+- `app.combat` contains reusable combat rules and contracts, while
+  `app.enemies` contains enemy definitions, runtime state, registration,
+  scaling, factory, and authored enemy content.
 - Core Defend contract integrated into Battle as a resolver-backed core action,
   not an authored `Move`.
 - Battle consumes `CombatResolver` and passes `CombatState` into resolver calls.
@@ -89,15 +92,22 @@ The repository now includes these active foundations:
   from `foe.combat_moves`.
 - Accepted combat actions complete through
   `CombatState.complete_accepted_action(...)`.
-- Battle renders `MoveResult` data and HUD state while the resolver owns
-  validation, resource spending, accuracy, damage, healing, Super behavior, and
-  result creation.
+- Battle renders `MoveResult` data and the terminal HUD, while the resolver
+  owns validation, resource spending, accuracy, damage, healing, Super
+  behavior, and result creation.
+- Player starting HP and Mana now derive from Constitution, Spirit, and level
+  through the stat-scaling contract instead of hardcoded archetype resource
+  constants.
+- Combat damage output now uses basis-point primary stat scaling instead of raw
+  additive stat damage, and ordinary physical negation, accuracy, dodge, Super
+  gain, and crit chance are wired through the shared scaling helpers.
 - Serializable `PlayerState` and `GameState` snapshots.
 - Defensive copies or immutable views for state collections where currently
   implemented.
 
-These systems are architecture and contract foundations. The Goblin encounter
-uses the structured path; broader gameplay systems remain under development.
+These systems form the current gameplay and architecture foundation. The
+Goblin encounter is fully on the structured combat path, while broader
+gameplay systems remain under development.
 
 ## Resource Terminology
 
@@ -249,21 +259,46 @@ v0.2.8 completes the Milestone 8 structured Goblin Battle integration:
 - verified the Goblin vertical slice from character selection through victory
   using structured moves and resolver-backed combat
 
+### v0.2.8.5
+
+v0.2.8.5 adds the first post-M8 stat-scaling pass and targeted hardening:
+
+- added the central `app.player.scaling` contract for all six permanent stats
+- moved authored starting Level 1 stat distributions into player loadout modules
+- derived player HP from Constitution and player Mana from Spirit, including
+  level-based resource growth through explicit recalculation
+- replaced raw additive damage scaling with basis-point output scaling for
+  Strength, Dexterity, and Intelligence
+- wired Strength physical negation into incoming physical damage
+- wired Dexterity accuracy and dodge into ordinary hit chance
+- wired Intuition Super gain scaling into landed non-Super damage hits
+- wired Intuition crit chance into landed damage moves and surfaced crit state
+  through `MoveResult`
+- updated Battle rendering to visibly show critical hits
+- added resolver compatibility coverage proving all four authored Drifter
+  structured move rosters enter the resolver path successfully
+- completed an M8 hardening audit across combat, player, enemy, snapshot, and
+  progression boundaries without changing move data, enemy data, or Battle flow
+
 ## Known Limitations
 
 - Items are visible in the Battle menu but not yet wired.
 - Joruun's full structured combat identity and specialized mechanics remain
   deferred.
 - Exact combat formulas and balance are provisional.
+- XP, Growth Points, secured/unsecured extraction loops, and reward persistence
+  remain parked for a later progression milestone.
 - Momentum implementation is deferred.
 - Ammunition, compounds, and prepared-charge systems are not implemented.
 - Status effects and elemental interactions are not active.
+- Temporary effect storage exists only as placeholder encounter state; a fuller
+  effect contract remains future work.
 - Enemy AI is still simple random selection from authored structured moves.
 - Multi-enemy, party-targeting, and area-targeting encounters are not
   implemented.
-- Equipment contributes through `effective_stat()` where implemented.
-- Broader encounters, progression gameplay, shops, extraction, and save/load are
-  future work.
+- Equipment currently contributes through `effective_stat()` where applicable.
+- Broader encounters, progression gameplay, shops, extraction, and save/load
+  remain future work.
 
 ## Development Notes
 

--- a/src/app/combat/battle.py
+++ b/src/app/combat/battle.py
@@ -86,7 +86,11 @@ class Battle:
             self._render_move_result_details(result)
             return
         if result.damage:
-            print(f"{actor_name} used {result.move_name}. It dealt {result.damage} damage.")
+            critical_text = " Critical hit!" if result.critical else ""
+            print(
+                f"{actor_name} used {result.move_name}."
+                f"{critical_text} It dealt {result.damage} damage."
+            )
             self._render_move_result_details(result)
             return
         if result.healing:

--- a/src/app/combat/resolver.py
+++ b/src/app/combat/resolver.py
@@ -218,7 +218,17 @@ def _apply_damage(actor, target, move, *, combat_state=None):
     scaled_power = _scaled_damage_power(actor, move)
     mitigation = _mitigation(target, move.damage_type)
     normal_damage = max(1, scaled_power - mitigation)
-    final_damage = _defended_damage(target, move.damage_type, normal_damage, combat_state)
+    damage_after_strength_negation = _strength_negated_damage(
+        target,
+        move.damage_type,
+        normal_damage,
+    )
+    final_damage = _defended_damage(
+        target,
+        move.damage_type,
+        damage_after_strength_negation,
+        combat_state,
+    )
 
     before = target.health.current
     target.health.take_damage(final_damage)
@@ -282,6 +292,21 @@ def _mitigation(target, damage_type):
         defense_value = 0
 
     return defense_value // 4
+
+
+def _strength_physical_negation_bps(target, damage_type):
+    if damage_type != DamageType.PHYSICAL:
+        return 0
+
+    return scaling.physical_negation_bps_from_strength(
+        target.effective_stat("strength")
+    )
+
+
+def _strength_negated_damage(target, damage_type, normal_damage):
+    negation_bps = _strength_physical_negation_bps(target, damage_type)
+    reduction_amount = normal_damage * negation_bps // BASIS_POINTS
+    return max(1, normal_damage - reduction_amount)
 
 
 def _defended_damage(target, damage_type, normal_damage, combat_state):

--- a/src/app/combat/resolver.py
+++ b/src/app/combat/resolver.py
@@ -6,8 +6,10 @@ from app.combat.combat_state import CombatState
 from app.combat.combatant import Combatant
 from app.combat.move import DamageType, MoveKind, ResourceType, ScalingAttribute, TargetType
 from app.combat.result import MoveResult
+from app.player import scaling
 
 
+BASIS_POINTS = 10_000
 SUPPORTED_MECHANICS = (None, "basic_attack", "heavy_attack")
 SUPER_GAIN_PER_ACCEPTED_NON_SUPER_ACTION = 10
 
@@ -214,14 +216,50 @@ def _scaling_value(actor, move):
 
 
 def _apply_damage(actor, target, move, *, combat_state=None):
-    raw_damage = move.power + _scaling_value(actor, move)
+    scaled_power = _scaled_damage_power(actor, move)
     mitigation = _mitigation(target, move.damage_type)
-    normal_damage = max(1, raw_damage - mitigation)
+    normal_damage = max(1, scaled_power - mitigation)
     final_damage = _defended_damage(target, move.damage_type, normal_damage, combat_state)
 
     before = target.health.current
     target.health.take_damage(final_damage)
     return before - target.health.current
+
+
+def _scaled_damage_power(actor, move):
+    output_bonus_bps = _damage_output_bonus_bps(actor, move)
+    return move.power * (BASIS_POINTS + output_bonus_bps) // BASIS_POINTS
+
+
+def _damage_output_bonus_bps(actor, move):
+    bonuses = []
+
+    for attribute in move.scales_with:
+        bonus = _output_bonus_bps_for_attribute(actor, attribute)
+        if bonus is not None:
+            bonuses.append(bonus)
+
+    if not bonuses:
+        return 0
+
+    return sum(bonuses) // len(bonuses)
+
+
+def _output_bonus_bps_for_attribute(actor, attribute):
+    if attribute == ScalingAttribute.STRENGTH:
+        return scaling.physical_output_bonus_bps_from_strength(
+            actor.effective_stat("strength")
+        )
+    if attribute == ScalingAttribute.DEXTERITY:
+        return scaling.physical_output_bonus_bps_from_dexterity(
+            actor.effective_stat("dexterity")
+        )
+    if attribute == ScalingAttribute.INTELLIGENCE:
+        return scaling.magical_output_bonus_bps_from_intelligence(
+            actor.effective_stat("intelligence")
+        )
+
+    return None
 
 
 def _apply_healing(actor, target, move):

--- a/src/app/combat/resolver.py
+++ b/src/app/combat/resolver.py
@@ -10,7 +10,8 @@ from app.player import scaling
 
 
 BASIS_POINTS = 10_000
-ORDINARY_FINAL_HIT_CHANCE_MAX = 95
+MAX_ORDINARY_HIT_CHANCE = 95
+MIN_ORDINARY_HIT_CHANCE = 5
 SUPPORTED_MECHANICS = (None, "basic_attack", "heavy_attack")
 SUPER_GAIN_PER_LANDED_NON_SUPER_DAMAGE = 10
 
@@ -54,7 +55,7 @@ class CombatResolver:
 
         resource_spent = _spend_resource(actor, move)
         roll = self.rng.randint(1, 100)
-        hit = roll <= _final_hit_chance(actor, move)
+        hit = roll <= _final_hit_chance(actor, target, move)
 
         damage = 0
         healing = 0
@@ -330,8 +331,17 @@ def _dexterity_accuracy_bonus_percent(actor):
     ) // 100
 
 
-def _final_hit_chance(actor, move):
-    return min(
-        ORDINARY_FINAL_HIT_CHANCE_MAX,
-        move.accuracy + _dexterity_accuracy_bonus_percent(actor),
+def _dexterity_dodge_bonus_percent(target):
+    return scaling.dodge_bonus_bps_from_dexterity(
+        target.effective_stat("dexterity")
+    ) // 100
+
+
+def _final_hit_chance(actor, target, move):
+    raw_hit_chance = (
+        move.accuracy
+        + _dexterity_accuracy_bonus_percent(actor)
+        - _dexterity_dodge_bonus_percent(target)
     )
+    final_hit_chance = min(MAX_ORDINARY_HIT_CHANCE, raw_hit_chance)
+    return max(MIN_ORDINARY_HIT_CHANCE, final_hit_chance)

--- a/src/app/combat/resolver.py
+++ b/src/app/combat/resolver.py
@@ -12,6 +12,9 @@ from app.player import scaling
 BASIS_POINTS = 10_000
 MAX_ORDINARY_HIT_CHANCE = 95
 MIN_ORDINARY_HIT_CHANCE = 5
+BASE_ORDINARY_CRIT_CHANCE = 0
+MAX_ORDINARY_CRIT_CHANCE = 35
+CRITICAL_DAMAGE_MULTIPLIER_PERCENT = 150
 SUPPORTED_MECHANICS = (None, "basic_attack", "heavy_attack")
 SUPER_GAIN_PER_LANDED_NON_SUPER_DAMAGE = 10
 
@@ -59,9 +62,17 @@ class CombatResolver:
 
         damage = 0
         healing = 0
+        critical = False
         if hit:
             if move.kind == MoveKind.DAMAGE:
-                damage = _apply_damage(actor, target, move, combat_state=combat_state)
+                critical = _rolled_critical_hit(actor, self.rng)
+                damage = _apply_damage(
+                    actor,
+                    target,
+                    move,
+                    combat_state=combat_state,
+                    critical=critical,
+                )
             elif move.kind == MoveKind.HEALING:
                 healing = _apply_healing(actor, target, move)
 
@@ -77,6 +88,7 @@ class CombatResolver:
             healing=healing,
             statuses_applied=(),
             reason=None,
+            critical=critical,
         )
 
     def resolve_defend(self, actor, combat_state):
@@ -100,6 +112,7 @@ class CombatResolver:
             healing=0,
             statuses_applied=(),
             reason=None,
+            critical=False,
         )
 
 
@@ -113,6 +126,7 @@ def _rejected(move_name, reason):
         healing=0,
         statuses_applied=(),
         reason=reason,
+        critical=False,
     )
 
 
@@ -216,7 +230,21 @@ def _scaling_value(actor, move):
     return sum(values) // len(values)
 
 
-def _apply_damage(actor, target, move, *, combat_state=None):
+def _apply_damage(actor, target, move, *, combat_state=None, critical=False):
+    final_damage = _landed_damage(
+        actor,
+        target,
+        move,
+        combat_state=combat_state,
+        critical=critical,
+    )
+
+    before = target.health.current
+    target.health.take_damage(final_damage)
+    return before - target.health.current
+
+
+def _landed_damage(actor, target, move, *, combat_state=None, critical=False):
     scaled_power = _scaled_damage_power(actor, move)
     mitigation = _mitigation(target, move.damage_type)
     normal_damage = max(1, scaled_power - mitigation)
@@ -231,10 +259,13 @@ def _apply_damage(actor, target, move, *, combat_state=None):
         damage_after_strength_negation,
         combat_state,
     )
+    if critical:
+        return max(
+            1,
+            final_damage * CRITICAL_DAMAGE_MULTIPLIER_PERCENT // 100,
+        )
 
-    before = target.health.current
-    target.health.take_damage(final_damage)
-    return before - target.health.current
+    return final_damage
 
 
 def _scaled_damage_power(actor, move):
@@ -353,3 +384,17 @@ def _final_hit_chance(actor, target, move):
     )
     final_hit_chance = min(MAX_ORDINARY_HIT_CHANCE, raw_hit_chance)
     return max(MIN_ORDINARY_HIT_CHANCE, final_hit_chance)
+
+
+def _final_crit_chance(actor):
+    raw_crit_chance = (
+        BASE_ORDINARY_CRIT_CHANCE
+        + scaling.crit_bonus_bps_from_intuition(
+            actor.effective_stat("intuition")
+        ) // 100
+    )
+    return min(MAX_ORDINARY_CRIT_CHANCE, raw_crit_chance)
+
+
+def _rolled_critical_hit(actor, rng):
+    return rng.randint(1, 100) <= _final_crit_chance(actor)

--- a/src/app/combat/resolver.py
+++ b/src/app/combat/resolver.py
@@ -322,7 +322,15 @@ def _defended_damage(target, damage_type, normal_damage, combat_state):
 
 def _grant_super_for_landed_non_super_damage(actor):
     if actor.generates_super:
-        actor.super_resource.gain(SUPER_GAIN_PER_LANDED_NON_SUPER_DAMAGE)
+        bonus_bps = scaling.super_gain_bonus_bps_from_intuition(
+            actor.effective_stat("intuition")
+        )
+        gained_super = (
+            SUPER_GAIN_PER_LANDED_NON_SUPER_DAMAGE
+            * (BASIS_POINTS + bonus_bps)
+            // BASIS_POINTS
+        )
+        actor.super_resource.gain(gained_super)
 
 
 def _dexterity_accuracy_bonus_percent(actor):

--- a/src/app/combat/resolver.py
+++ b/src/app/combat/resolver.py
@@ -10,6 +10,7 @@ from app.player import scaling
 
 
 BASIS_POINTS = 10_000
+ORDINARY_FINAL_HIT_CHANCE_MAX = 95
 SUPPORTED_MECHANICS = (None, "basic_attack", "heavy_attack")
 SUPER_GAIN_PER_LANDED_NON_SUPER_DAMAGE = 10
 
@@ -53,7 +54,7 @@ class CombatResolver:
 
         resource_spent = _spend_resource(actor, move)
         roll = self.rng.randint(1, 100)
-        hit = roll <= move.accuracy
+        hit = roll <= _final_hit_chance(actor, move)
 
         damage = 0
         healing = 0
@@ -321,3 +322,16 @@ def _defended_damage(target, damage_type, normal_damage, combat_state):
 def _grant_super_for_landed_non_super_damage(actor):
     if actor.generates_super:
         actor.super_resource.gain(SUPER_GAIN_PER_LANDED_NON_SUPER_DAMAGE)
+
+
+def _dexterity_accuracy_bonus_percent(actor):
+    return scaling.accuracy_bonus_bps_from_dexterity(
+        actor.effective_stat("dexterity")
+    ) // 100
+
+
+def _final_hit_chance(actor, move):
+    return min(
+        ORDINARY_FINAL_HIT_CHANCE_MAX,
+        move.accuracy + _dexterity_accuracy_bonus_percent(actor),
+    )

--- a/src/app/combat/resolver.py
+++ b/src/app/combat/resolver.py
@@ -11,7 +11,7 @@ from app.player import scaling
 
 BASIS_POINTS = 10_000
 SUPPORTED_MECHANICS = (None, "basic_attack", "heavy_attack")
-SUPER_GAIN_PER_ACCEPTED_NON_SUPER_ACTION = 10
+SUPER_GAIN_PER_LANDED_NON_SUPER_DAMAGE = 10
 
 
 class CombatResolver:
@@ -63,8 +63,8 @@ class CombatResolver:
             elif move.kind == MoveKind.HEALING:
                 healing = _apply_healing(actor, target, move)
 
-        if move.resource_type != ResourceType.SUPER:
-            _grant_super_for_accepted_non_super_action(actor)
+        if hit and move.kind == MoveKind.DAMAGE and move.resource_type != ResourceType.SUPER:
+            _grant_super_for_landed_non_super_damage(actor)
 
         return MoveResult(
             accepted=True,
@@ -88,7 +88,6 @@ class CombatResolver:
             return _rejected("Defend", "defend_not_available")
 
         combat_state.activate_defend(actor)
-        _grant_super_for_accepted_non_super_action(actor)
 
         return MoveResult(
             accepted=True,
@@ -294,6 +293,6 @@ def _defended_damage(target, damage_type, normal_damage, combat_state):
     return max(1, normal_damage - reduction_amount)
 
 
-def _grant_super_for_accepted_non_super_action(actor):
+def _grant_super_for_landed_non_super_damage(actor):
     if actor.generates_super:
-        actor.super_resource.gain(SUPER_GAIN_PER_ACCEPTED_NON_SUPER_ACTION)
+        actor.super_resource.gain(SUPER_GAIN_PER_LANDED_NON_SUPER_DAMAGE)

--- a/src/app/combat/result.py
+++ b/src/app/combat/result.py
@@ -13,10 +13,12 @@ class MoveResult:
     healing: int
     statuses_applied: tuple[str, ...]
     reason: str | None
+    critical: bool = False
 
     def __post_init__(self):
         object.__setattr__(self, "accepted", _validate_bool("accepted", self.accepted))
         object.__setattr__(self, "hit", _validate_bool("hit", self.hit))
+        object.__setattr__(self, "critical", _validate_bool("critical", self.critical))
         object.__setattr__(self, "move_name", _validate_nonempty_string("move_name", self.move_name))
         object.__setattr__(
             self,

--- a/src/app/player/character.py
+++ b/src/app/player/character.py
@@ -151,14 +151,9 @@ def _validate_level_one_stat_total(stat_values):
 
 class Brawler(Character):
     def __init__(self):
-        stat_values = _validate_level_one_stat_total({
-            "constitution": 14,
-            "spirit": 6,
-            "intelligence": 5,
-            "strength": 15,
-            "dexterity": 10,
-            "intuition": 10,
-        })
+        stat_values = _validate_level_one_stat_total(
+            branoc.create_starting_stats()
+        )
         super().__init__(
             **stat_values,
             hp=60,
@@ -172,14 +167,9 @@ class Brawler(Character):
 
 class BlackMage(Character):
     def __init__(self):
-        stat_values = _validate_level_one_stat_total({
-            "constitution": 7,
-            "spirit": 13,
-            "intelligence": 15,
-            "strength": 5,
-            "dexterity": 8,
-            "intuition": 12,
-        })
+        stat_values = _validate_level_one_stat_total(
+            azhvielle.create_starting_stats()
+        )
         super().__init__(
             **stat_values,
             hp=30,
@@ -193,14 +183,9 @@ class BlackMage(Character):
 
 class RogueArcher(Character):
     def __init__(self):
-        stat_values = _validate_level_one_stat_total({
-            "constitution": 8,
-            "spirit": 7,
-            "intelligence": 10,
-            "strength": 6,
-            "dexterity": 15,
-            "intuition": 14,
-        })
+        stat_values = _validate_level_one_stat_total(
+            zhaivra.create_starting_stats()
+        )
         super().__init__(
             **stat_values,
             hp=45,
@@ -214,14 +199,9 @@ class RogueArcher(Character):
 
 class Monk(Character):
     def __init__(self):
-        stat_values = _validate_level_one_stat_total({
-            "constitution": 10,
-            "spirit": 10,
-            "intelligence": 13,
-            "strength": 7,
-            "dexterity": 12,
-            "intuition": 8,
-        })
+        stat_values = _validate_level_one_stat_total(
+            joruun.create_starting_stats()
+        )
         super().__init__(
             **stat_values,
             hp=60,

--- a/src/app/player/character.py
+++ b/src/app/player/character.py
@@ -1,5 +1,6 @@
 from app.player import progression
 from app.player import resources
+from app.player import scaling
 from app.player import stats
 from app.player.loadouts import azhvielle
 from app.player.loadouts import branoc
@@ -16,8 +17,6 @@ class Character:
             strength,
             dexterity,
             intuition,
-            hp,
-            mana,
             name,
             moves,
             combat_moves=None,
@@ -38,11 +37,50 @@ class Character:
         self.class_mechanic = dict(class_mechanic or {})
         self.starting_equipment = dict(starting_equipment or {})
         self.profile = None
-        self.stats = stats.Stats(self.permanent_stats)
-        self.health = resources.Health(maximum=hp)
-        self.mana_resource = resources.Mana(maximum=mana)
         self.level_state = progression.Level()
+        self.stats = stats.Stats(self.permanent_stats)
+        self.health = resources.Health(
+            maximum=scaling.maximum_hp_from_constitution(
+                self.permanent_stats.constitution,
+                level=self.level_state.current,
+            )
+        )
+        self.mana_resource = resources.Mana(
+            maximum=scaling.maximum_mana_from_spirit(
+                self.permanent_stats.spirit,
+                level=self.level_state.current,
+            )
+        )
         self.exp_state = progression.Exp(self.level_state)
+
+    def recalculate_resource_maximums(self, increase_current=False):
+        new_health_maximum = scaling.maximum_hp_from_constitution(
+            self.permanent_stats.constitution,
+            level=self.level_state.current,
+        )
+        new_mana_maximum = scaling.maximum_mana_from_spirit(
+            self.permanent_stats.spirit,
+            level=self.level_state.current,
+        )
+
+        self._set_resource_maximum(
+            self.health,
+            new_health_maximum,
+            increase_current=increase_current,
+        )
+        self._set_resource_maximum(
+            self.mana_resource,
+            new_mana_maximum,
+            increase_current=increase_current,
+        )
+
+    @staticmethod
+    def _set_resource_maximum(resource, new_maximum, *, increase_current):
+        delta = new_maximum - resource.maximum
+        if delta > 0:
+            resource.increase_maximum(delta, increase_current=increase_current)
+        elif delta < 0:
+            resource.decrease_maximum(-delta)
 
     @property
     def constitution(self):
@@ -156,8 +194,6 @@ class Brawler(Character):
         )
         super().__init__(
             **stat_values,
-            hp=60,
-            mana=10,
             name="Brawler",
             moves=branoc.create_legacy_moves(),
             combat_moves=branoc.create_combat_moves(),
@@ -172,8 +208,6 @@ class BlackMage(Character):
         )
         super().__init__(
             **stat_values,
-            hp=30,
-            mana=70,
             name="Black Mage",
             moves=azhvielle.create_legacy_moves(),
             combat_moves=azhvielle.create_combat_moves(),
@@ -188,8 +222,6 @@ class RogueArcher(Character):
         )
         super().__init__(
             **stat_values,
-            hp=45,
-            mana=20,
             name="Rogue Archer",
             moves=zhaivra.create_legacy_moves(),
             combat_moves=zhaivra.create_combat_moves(),
@@ -204,8 +236,6 @@ class Monk(Character):
         )
         super().__init__(
             **stat_values,
-            hp=60,
-            mana=20,
             name="Monk",
             moves=joruun.create_legacy_moves(),
             combat_moves=joruun.create_combat_moves(),

--- a/src/app/player/loadouts/azhvielle.py
+++ b/src/app/player/loadouts/azhvielle.py
@@ -2,6 +2,17 @@ from app.combat.move import DamageType, Move, MoveKind, ResourceType, ScalingAtt
 from app.items.weapon import NeedleOfPlainIron
 
 
+def create_starting_stats():
+    return {
+        "constitution": 7,
+        "spirit": 13,
+        "intelligence": 15,
+        "strength": 5,
+        "dexterity": 8,
+        "intuition": 12,
+    }
+
+
 def create_legacy_moves():
     return {
         1: 'Scepter Sweep',

--- a/src/app/player/loadouts/branoc.py
+++ b/src/app/player/loadouts/branoc.py
@@ -67,8 +67,8 @@ def create_combat_moves():
         Move(
             name='Ironwake Dismemberment',
             kind=MoveKind.DAMAGE,
-            resource_type=ResourceType.MANA,
-            resource_cost=3,
+            resource_type=ResourceType.NONE,
+            resource_cost=0,
             power=14,
             scales_with=(ScalingAttribute.STRENGTH,),
             accuracy=82,

--- a/src/app/player/loadouts/branoc.py
+++ b/src/app/player/loadouts/branoc.py
@@ -2,6 +2,17 @@ from app.combat.move import DamageType, Move, MoveKind, ResourceType, ScalingAtt
 from app.items.weapon import SunderSpire
 
 
+def create_starting_stats():
+    return {
+        "constitution": 14,
+        "spirit": 6,
+        "intelligence": 5,
+        "strength": 15,
+        "dexterity": 10,
+        "intuition": 10,
+    }
+
+
 def create_legacy_moves():
     return {
         1: 'Crestgrave Reaping',

--- a/src/app/player/loadouts/joruun.py
+++ b/src/app/player/loadouts/joruun.py
@@ -2,6 +2,17 @@ from app.combat.move import DamageType, Move, MoveKind, ResourceType, ScalingAtt
 from app.items.weapon import SkyNeedle
 
 
+def create_starting_stats():
+    return {
+        "constitution": 10,
+        "spirit": 10,
+        "intelligence": 13,
+        "strength": 7,
+        "dexterity": 12,
+        "intuition": 8,
+    }
+
+
 def create_legacy_moves():
     return {
         1: 'Bring the Horse to Water',

--- a/src/app/player/loadouts/zhaivra.py
+++ b/src/app/player/loadouts/zhaivra.py
@@ -2,6 +2,17 @@ from app.combat.move import DamageType, Move, MoveKind, ResourceType, ScalingAtt
 from app.items.weapon import Sathren
 
 
+def create_starting_stats():
+    return {
+        "constitution": 8,
+        "spirit": 7,
+        "intelligence": 10,
+        "strength": 6,
+        "dexterity": 15,
+        "intuition": 14,
+    }
+
+
 def create_legacy_moves():
     return {
         1: 'Mournpoint Verdict',

--- a/src/app/player/scaling.py
+++ b/src/app/player/scaling.py
@@ -1,0 +1,243 @@
+STAT_MINIMUM = 1
+STAT_MAXIMUM = 100
+
+
+_PRIMARY_OUTPUT_BPS_MILESTONES = {
+    10: 0,
+    20: 2500,
+    40: 6500,
+    60: 9500,
+    80: 11000,
+    100: 12000,
+}
+
+_STRENGTH_PHYSICAL_NEGATION_BPS_MILESTONES = {
+    10: 0,
+    20: 500,
+    40: 1500,
+    60: 2400,
+    80: 3000,
+    100: 3400,
+}
+
+_DEXTERITY_ACCURACY_BPS_MILESTONES = {
+    10: 0,
+    20: 400,
+    40: 1000,
+    60: 1500,
+    80: 1800,
+    100: 2000,
+}
+
+_DEXTERITY_DODGE_BPS_MILESTONES = {
+    10: 0,
+    20: 200,
+    40: 600,
+    60: 1000,
+    80: 1300,
+    100: 1500,
+}
+
+_INTUITION_SPECIAL_POTENCY_BPS_MILESTONES = {
+    10: 0,
+    20: 1000,
+    40: 2500,
+    60: 3500,
+    80: 4200,
+    100: 5000,
+}
+
+_INTUITION_CRIT_BPS_MILESTONES = {
+    10: 0,
+    20: 200,
+    40: 600,
+    60: 1000,
+    80: 1300,
+    100: 1500,
+}
+
+_INTUITION_SUPER_GAIN_BPS_MILESTONES = {
+    10: 0,
+    20: 1000,
+    40: 2500,
+    60: 4000,
+    80: 5000,
+    100: 6000,
+}
+
+_INTUITION_DISCOVERY_BPS_MILESTONES = {
+    10: 0,
+    20: 1000,
+    40: 2500,
+    60: 4000,
+    80: 5500,
+    100: 7000,
+}
+
+_INTUITION_SECURED_XP_BPS_MILESTONES = {
+    10: 0,
+    20: 100,
+    40: 400,
+    60: 700,
+    80: 1000,
+    100: 1200,
+}
+
+
+def maximum_hp_from_constitution(constitution: int, level: int = 1) -> int:
+    constitution = _validate_stat(constitution, name="constitution")
+    level = _validate_level(level)
+
+    hp = 100
+    if constitution < 10:
+        hp -= (10 - constitution) * 3
+    else:
+        hp += _points_above_baseline(
+            constitution,
+            (
+                (20, 4),
+                (40, 7),
+                (60, 5),
+                (80, 3),
+                (100, 2),
+            ),
+        )
+
+    return hp + (level - 1) * 4
+
+
+def maximum_mana_from_spirit(spirit: int, level: int = 1) -> int:
+    spirit = _validate_stat(spirit, name="spirit")
+    level = _validate_level(level)
+
+    mana = 50
+    if spirit < 10:
+        mana -= 10 - spirit
+    else:
+        mana += _points_above_baseline(
+            spirit,
+            (
+                (20, 2),
+                (40, 4),
+                (60, 3),
+                (80, 2),
+                (100, 1),
+            ),
+        )
+
+    return mana + (level - 1)
+
+
+def magical_output_bonus_bps_from_intelligence(intelligence: int) -> int:
+    intelligence = _validate_stat(intelligence, name="intelligence")
+    return _interpolated_bps(intelligence, _PRIMARY_OUTPUT_BPS_MILESTONES)
+
+
+def physical_output_bonus_bps_from_strength(strength: int) -> int:
+    strength = _validate_stat(strength, name="strength")
+    return _interpolated_bps(strength, _PRIMARY_OUTPUT_BPS_MILESTONES)
+
+
+def physical_negation_bps_from_strength(strength: int) -> int:
+    strength = _validate_stat(strength, name="strength")
+    return _interpolated_bps(strength, _STRENGTH_PHYSICAL_NEGATION_BPS_MILESTONES)
+
+
+def physical_output_bonus_bps_from_dexterity(dexterity: int) -> int:
+    dexterity = _validate_stat(dexterity, name="dexterity")
+    return _interpolated_bps(dexterity, _PRIMARY_OUTPUT_BPS_MILESTONES)
+
+
+def accuracy_bonus_bps_from_dexterity(dexterity: int) -> int:
+    dexterity = _validate_stat(dexterity, name="dexterity")
+    return _interpolated_bps(dexterity, _DEXTERITY_ACCURACY_BPS_MILESTONES)
+
+
+def dodge_bonus_bps_from_dexterity(dexterity: int) -> int:
+    dexterity = _validate_stat(dexterity, name="dexterity")
+    return _interpolated_bps(dexterity, _DEXTERITY_DODGE_BPS_MILESTONES)
+
+
+def special_potency_bps_from_intuition(intuition: int) -> int:
+    intuition = _validate_stat(intuition, name="intuition")
+    return _interpolated_bps(intuition, _INTUITION_SPECIAL_POTENCY_BPS_MILESTONES)
+
+
+def crit_bonus_bps_from_intuition(intuition: int) -> int:
+    intuition = _validate_stat(intuition, name="intuition")
+    return _interpolated_bps(intuition, _INTUITION_CRIT_BPS_MILESTONES)
+
+
+def super_gain_bonus_bps_from_intuition(intuition: int) -> int:
+    intuition = _validate_stat(intuition, name="intuition")
+    return _interpolated_bps(intuition, _INTUITION_SUPER_GAIN_BPS_MILESTONES)
+
+
+def discovery_bonus_bps_from_intuition(intuition: int) -> int:
+    intuition = _validate_stat(intuition, name="intuition")
+    return _interpolated_bps(intuition, _INTUITION_DISCOVERY_BPS_MILESTONES)
+
+
+def secured_xp_bonus_bps_from_intuition(intuition: int) -> int:
+    intuition = _validate_stat(intuition, name="intuition")
+    return _interpolated_bps(intuition, _INTUITION_SECURED_XP_BPS_MILESTONES)
+
+
+def _validate_stat(value: int, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer")
+    if value < STAT_MINIMUM or value > STAT_MAXIMUM:
+        raise ValueError(
+            f"{name} must be between {STAT_MINIMUM} and {STAT_MAXIMUM}"
+        )
+
+    return value
+
+
+def _validate_level(level: int) -> int:
+    if isinstance(level, bool) or not isinstance(level, int):
+        raise TypeError("level must be an integer")
+    if level < 1:
+        raise ValueError("level must be at least 1")
+
+    return level
+
+
+def _points_above_baseline(stat: int, brackets: tuple[tuple[int, int], ...]) -> int:
+    total = 0
+    previous_limit = 10
+    for limit, points_per_stat in brackets:
+        if stat <= previous_limit:
+            break
+
+        points_in_bracket = min(stat, limit) - previous_limit
+        total += points_in_bracket * points_per_stat
+        previous_limit = limit
+
+    return total
+
+
+def _interpolated_bps(stat: int, milestones: dict[int, int]) -> int:
+    ordered_stats = sorted(milestones)
+
+    if stat in milestones:
+        return milestones[stat]
+
+    lower_stat = ordered_stats[0]
+    upper_stat = ordered_stats[1]
+
+    if stat > lower_stat:
+        for candidate in ordered_stats:
+            if candidate < stat:
+                lower_stat = candidate
+                continue
+
+            upper_stat = candidate
+            break
+
+    lower_value = milestones[lower_stat]
+    upper_value = milestones[upper_stat]
+    span = upper_stat - lower_stat
+    offset = stat - lower_stat
+
+    return lower_value + (upper_value - lower_value) * offset // span

--- a/src/app/player/stats.py
+++ b/src/app/player/stats.py
@@ -129,12 +129,6 @@ class Stats:
     def defense_rating(self):
         return max(0, self.constitution * 2 + self.dexterity // 2)
 
-    def health_bonus(self):
-        return max(0, self.constitution * 5)
-
-    def mana_bonus(self):
-        return max(0, self.spirit * 5)
-
     def luck_rating(self):
         return max(0, self.intuition + self.dexterity // 2)
 
@@ -143,12 +137,6 @@ class Stats:
 
     def defense(self):
         return self.defense_rating()
-
-    def health(self):
-        return self.health_bonus()
-
-    def mana(self):
-        return self.mana_bonus()
 
     def luck(self):
         return self.luck_rating()

--- a/tests/smoke_test_vertical_slice.py
+++ b/tests/smoke_test_vertical_slice.py
@@ -66,7 +66,7 @@ def patched_game(inputs):
 def test_attack_path_reaches_victory_ending():
     output = io.StringIO()
 
-    with patched_game(["", "4", "Y", "1", "2", "1", "2", "1", "3"]), contextlib.redirect_stdout(output):
+    with patched_game(["", "4", "Y", "1", "1", "2", "1", "2", "1", "2", "1", "2", "1", "2", "1", "2"]), contextlib.redirect_stdout(output):
         run_game.main()
 
     text = output.getvalue()

--- a/tests/test_battle_player_state.py
+++ b/tests/test_battle_player_state.py
@@ -191,13 +191,18 @@ def test_complete_accepted_action_does_nothing_when_result_is_rejected():
     assert battle.combat_state.is_defending(enemy_state)
 
 
-def test_result_renderer_prints_actual_damage_healing_miss_rejection_resources_and_statuses():
+def test_result_renderer_prints_critical_damage_and_preserves_other_result_rendering():
     battle = Battle(PlayerState(Brawler()), EnemyState(Goblin()))
     output = io.StringIO()
 
     with contextlib.redirect_stdout(output):
         battle._render_move_result(
             result_with(move_name="Cut", damage=7),
+            actor=battle.player_state,
+            target=battle.foe,
+        )
+        battle._render_move_result(
+            result_with(move_name="Smash", damage=16, critical=True),
             actor=battle.player_state,
             target=battle.foe,
         )
@@ -232,6 +237,7 @@ def test_result_renderer_prints_actual_damage_healing_miss_rejection_resources_a
 
     text = output.getvalue()
     assert "Brawler used Cut. It dealt 7 damage." in text
+    assert "Brawler used Smash. Critical hit! It dealt 16 damage." in text
     assert "Brawler used Recover. It restored 3 health." in text
     assert "Goblin used Whiff, but missed." in text
     assert "Brawler used test move, but it failed: rejected." in text
@@ -240,6 +246,7 @@ def test_result_renderer_prints_actual_damage_healing_miss_rejection_resources_a
     assert "Brawler used Defend." in text
     assert "Defend missed" not in text
     assert "Whiff. It dealt" not in text
+    assert "Brawler used Cut. Critical hit!" not in text
 
 
 def test_player_main_menu_shows_structured_actions_without_legacy_recover_or_labels():

--- a/tests/test_battle_player_state.py
+++ b/tests/test_battle_player_state.py
@@ -775,12 +775,12 @@ def test_victory_returns_player():
         winner = battle.run()
 
     assert winner == "player"
-    assert battle.combat_state.turn_count == 3
+    assert battle.combat_state.turn_count == 5
 
 
 def test_defeat_returns_enemy_and_persists_player_health():
     player_state = PlayerState(Brawler())
-    player_state.health.take_damage(player_state.health.maximum - 5)
+    player_state.health.take_damage(player_state.health.maximum - 3)
     battle = Battle(player_state, EnemyState(Goblin()))
 
     def fake_randint(start, end):
@@ -823,8 +823,8 @@ def test_completed_actions_advance_turn_count():
             return 1
         return end
 
-    with patched_battle(inputs=["attack", "1", "attack", "1", "attack", "1"], randint=fake_randint), contextlib.redirect_stdout(io.StringIO()):
+    with patched_battle(inputs=["attack", "4", "attack", "4", "attack", "4", "attack", "4"], randint=fake_randint), contextlib.redirect_stdout(io.StringIO()):
         winner = battle.run()
 
     assert winner == "player"
-    assert battle.combat_state.turn_count == 5
+    assert battle.combat_state.turn_count == 7

--- a/tests/test_character_loadout_regression.py
+++ b/tests/test_character_loadout_regression.py
@@ -1,5 +1,6 @@
 from app.items.weapon import NeedleOfPlainIron, Sathren, SkyNeedle, SunderSpire
 from app.player.character import BlackMage, Brawler, Monk, RogueArcher
+from app.player.loadouts import azhvielle, branoc, joruun, zhaivra
 
 
 EXPECTED_LOADOUTS = {
@@ -374,6 +375,14 @@ EXPECTED_LOADOUTS = {
 }
 
 
+LOADOUT_MODULES = {
+    branoc: EXPECTED_LOADOUTS[Brawler]["attributes"],
+    azhvielle: EXPECTED_LOADOUTS[BlackMage]["attributes"],
+    zhaivra: EXPECTED_LOADOUTS[RogueArcher]["attributes"],
+    joruun: EXPECTED_LOADOUTS[Monk]["attributes"],
+}
+
+
 def move_to_dict(move):
     return {
         "name": move.name,
@@ -391,6 +400,24 @@ def move_to_dict(move):
         "mechanic": move.mechanic,
         "description": move.description,
     }
+
+
+def test_authored_starting_stats_live_in_loadout_modules():
+    for loadout_module, expected_stats in LOADOUT_MODULES.items():
+        starting_stats = loadout_module.create_starting_stats()
+
+        assert starting_stats == expected_stats
+        assert sum(starting_stats.values()) == 60
+
+
+def test_authored_starting_stats_are_returned_as_fresh_dictionaries():
+    for loadout_module, expected_stats in LOADOUT_MODULES.items():
+        first = loadout_module.create_starting_stats()
+        second = loadout_module.create_starting_stats()
+
+        first["constitution"] = 1
+
+        assert second == expected_stats
 
 
 def test_all_archetype_authored_loadout_data_is_unchanged():

--- a/tests/test_character_loadout_regression.py
+++ b/tests/test_character_loadout_regression.py
@@ -66,8 +66,8 @@ EXPECTED_LOADOUTS = {
             {
                 "name": "Ironwake Dismemberment",
                 "kind": "damage",
-                "resource_type": "mana",
-                "resource_cost": 3,
+                "resource_type": "none",
+                "resource_cost": 0,
                 "power": 14,
                 "scales_with": ["strength"],
                 "accuracy": 82,

--- a/tests/test_character_loadout_regression.py
+++ b/tests/test_character_loadout_regression.py
@@ -13,8 +13,8 @@ EXPECTED_LOADOUTS = {
             "dexterity": 10,
             "intuition": 10,
         },
-        "hp": 60,
-        "mana": 10,
+        "hp": 116,
+        "mana": 46,
         "name": "Brawler",
         "moves": {
             1: "Crestgrave Reaping",
@@ -105,8 +105,8 @@ EXPECTED_LOADOUTS = {
             "dexterity": 8,
             "intuition": 12,
         },
-        "hp": 30,
-        "mana": 70,
+        "hp": 91,
+        "mana": 56,
         "name": "Black Mage",
         "moves": {
             1: "Scepter Sweep",
@@ -197,8 +197,8 @@ EXPECTED_LOADOUTS = {
             "dexterity": 15,
             "intuition": 14,
         },
-        "hp": 45,
-        "mana": 20,
+        "hp": 94,
+        "mana": 47,
         "name": "Rogue Archer",
         "moves": {
             1: "Mournpoint Verdict",
@@ -289,8 +289,8 @@ EXPECTED_LOADOUTS = {
             "dexterity": 12,
             "intuition": 8,
         },
-        "hp": 60,
-        "mana": 20,
+        "hp": 100,
+        "mana": 50,
         "name": "Monk",
         "moves": {
             1: "Bring the Horse to Water",

--- a/tests/test_character_move_data.py
+++ b/tests/test_character_move_data.py
@@ -139,7 +139,7 @@ def test_brawler_roster_is_four_standard_attacks_and_one_super():
         ResourceType.NONE,
         ResourceType.MANA,
         ResourceType.MANA,
-        ResourceType.MANA,
+        ResourceType.NONE,
         ResourceType.SUPER,
     ]
     assert brawler.combat_moves[-1].resource_cost == 100
@@ -192,7 +192,7 @@ def test_loadout_resource_types_follow_authored_class_resources():
         ResourceType.NONE,
         ResourceType.MANA,
         ResourceType.MANA,
-        ResourceType.MANA,
+        ResourceType.NONE,
         ResourceType.SUPER,
     ]
     assert [move.resource_type for move in black_mage.combat_moves] == [

--- a/tests/test_character_state.py
+++ b/tests/test_character_state.py
@@ -204,8 +204,6 @@ def test_derived_stats_return_nonnegative_values():
         assert player.stats.intuition == player.intuition
         assert player.stats.attack_power() >= 0
         assert player.stats.defense_rating() >= 0
-        assert player.stats.health_bonus() >= 0
-        assert player.stats.mana_bonus() >= 0
         assert player.stats.luck_rating() >= 0
 
 

--- a/tests/test_character_state.py
+++ b/tests/test_character_state.py
@@ -297,8 +297,6 @@ def test_base_character_accepts_valid_progressed_stat_totals_above_sixty():
         strength=20,
         dexterity=20,
         intuition=20,
-        hp=100,
-        mana=50,
         name="Progressed Test Character",
         moves={1: "test strike"},
     )
@@ -307,6 +305,82 @@ def test_base_character_accepts_valid_progressed_stat_totals_above_sixty():
     assert character.strength == 20
     assert character.spirit == 20
     assert character.intuition == 20
+    assert character.health.maximum == 140
+    assert character.mana_resource.maximum == 70
+
+
+def test_character_resources_derive_from_starting_constitution_spirit_and_level():
+    expected = {
+        Brawler: (116, 46),
+        BlackMage: (91, 56),
+        RogueArcher: (94, 47),
+        Monk: (100, 50),
+    }
+
+    for class_type, (expected_hp, expected_mana) in expected.items():
+        character = class_type()
+
+        assert character.health.maximum == expected_hp
+        assert character.health.current == expected_hp
+        assert character.mana_resource.maximum == expected_mana
+        assert character.mana_resource.current == expected_mana
+
+
+def test_direct_level_mutation_does_not_recalculate_resource_maximums():
+    character = BlackMage()
+
+    character.level = 3
+
+    assert character.level_state.current == 3
+    assert character.health.maximum == 91
+    assert character.mana_resource.maximum == 56
+
+
+def test_explicit_resource_recalculation_updates_maximums_without_refill():
+    character = BlackMage()
+    character.health.take_damage(7)
+    character.mana_resource.spend(8)
+    character.level = 3
+
+    character.recalculate_resource_maximums(increase_current=False)
+
+    assert character.health.maximum == 99
+    assert character.health.current == 84
+    assert character.mana_resource.maximum == 58
+    assert character.mana_resource.current == 48
+
+
+def test_explicit_resource_recalculation_can_increase_current_by_positive_delta():
+    character = BlackMage()
+    character.health.take_damage(7)
+    character.mana_resource.spend(8)
+    character.level = 3
+
+    character.recalculate_resource_maximums(increase_current=True)
+
+    assert character.health.maximum == 99
+    assert character.health.current == 92
+    assert character.mana_resource.maximum == 58
+    assert character.mana_resource.current == 50
+
+
+def test_stat_mutation_does_not_recalculate_until_explicitly_requested():
+    character = BlackMage()
+    character.mana_resource.spend(10)
+
+    character.constitution = 10
+    character.spirit = 10
+
+    assert character.health.maximum == 91
+    assert character.mana_resource.maximum == 56
+    assert character.mana_resource.current == 46
+
+    character.recalculate_resource_maximums()
+
+    assert character.health.maximum == 100
+    assert character.health.current == 91
+    assert character.mana_resource.maximum == 50
+    assert character.mana_resource.current == 46
 
 
 def test_permanent_stats_validation_and_mutation():

--- a/tests/test_combat_resolver.py
+++ b/tests/test_combat_resolver.py
@@ -7,7 +7,7 @@ from app.enemies.state import EnemyState
 from app.combat.combat_state import CombatState
 from app.combat.move import DamageType, Move, MoveKind, ResourceType, ScalingAttribute, TargetType
 from app.combat.resolver import CombatResolver
-from app.player.character import BlackMage, Brawler
+from app.player.character import BlackMage, Brawler, Monk, RogueArcher
 from app.player.player_state import PlayerState
 
 
@@ -1670,6 +1670,39 @@ def test_every_ordinary_goblin_move_is_resolver_supported_without_filtering():
 
         assert result.accepted
         assert result.reason is None
+
+
+def test_all_four_drifter_structured_moves_are_resolver_compatible():
+    characters = (
+        Brawler,
+        BlackMage,
+        RogueArcher,
+        Monk,
+    )
+
+    for character_type in characters:
+        for prototype_move in PlayerState(character_type()).combat_moves:
+            actor = PlayerState(character_type())
+            target = (
+                actor
+                if prototype_move.target == TargetType.SELF
+                else EnemyState(Goblin())
+            )
+
+            if prototype_move.resource_type == ResourceType.SUPER:
+                actor.super_resource.gain(actor.super_resource.maximum)
+
+            result = CombatResolver(rng=ScriptedRng(1, 1)).resolve_move(
+                actor,
+                target,
+                prototype_move.name,
+            )
+
+            assert result.accepted, (
+                f"{character_type.__name__} move {prototype_move.name!r} "
+                f"should resolve through CombatResolver"
+            )
+            assert result.reason is None
 
 
 def test_resolver_does_not_print_or_read_input(monkeypatch):

--- a/tests/test_combat_resolver.py
+++ b/tests/test_combat_resolver.py
@@ -346,13 +346,13 @@ def test_mana_spending_affordability_and_miss_behavior():
     assert result.accepted
     assert not result.hit
     assert result.resource_spent == 3
-    assert actor.mana_resource.current == 7
+    assert actor.mana_resource.current == 43
     assert target.health.current == target.health.maximum
     assert actor.super_resource.current == 10
 
     actor = PlayerState(Brawler())
     target = EnemyState(Goblin())
-    actor.mana_resource.spend(8)
+    actor.mana_resource.spend(44)
     rng = ScriptedRng(1)
 
     result = CombatResolver(rng=rng).resolve_move(actor, target, "Ironwake Dismemberment")

--- a/tests/test_combat_resolver.py
+++ b/tests/test_combat_resolver.py
@@ -18,7 +18,9 @@ class ScriptedRng:
 
     def randint(self, start, end):
         self.calls.append((start, end))
-        return self.rolls.pop(0)
+        if self.rolls:
+            return self.rolls.pop(0)
+        return end
 
 
 class SimpleCombatant:
@@ -135,7 +137,7 @@ def test_owned_canonical_move_resolves_and_foreign_or_unknown_moves_are_rejected
     assert result.damage == 11
     assert target.health.current == 49
     assert actor.super_resource.current == 10
-    assert rng.calls == [(1, 100)]
+    assert rng.calls == [(1, 100), (1, 100)]
 
     foreign_move_name = PlayerState(BlackMage()).combat_moves[0].name
     actor_mana = actor.mana_resource.current
@@ -514,6 +516,160 @@ def test_battle_ending_damage_still_generates_super():
     assert actor.super_resource.current == 10
 
 
+def test_intuition_crit_bonus_applies_only_to_landed_damage_moves():
+    examples = (
+        (10, 0, 1, False, 10),
+        (20, 2, 2, True, 11),
+        (20, 2, 3, False, 11),
+        (40, 6, 6, True, 12),
+        (100, 15, 15, True, 16),
+    )
+
+    for intuition, expected_crit_chance, crit_roll, expected_critical, expected_super in examples:
+        move = make_move(
+            name=f"crit intuition {intuition}",
+            power=20,
+            scales_with=(ScalingAttribute.NONE,),
+        )
+        actor = SimpleCombatant(
+            moves=(move,),
+            effective_stats={
+                "constitution": 8,
+                "spirit": 8,
+                "intelligence": 8,
+                "strength": 8,
+                "dexterity": 10,
+                "intuition": intuition,
+            },
+        )
+        target = no_mitigation_target()
+
+        result = CombatResolver(rng=ScriptedRng(1, crit_roll)).resolve_move(
+            actor,
+            target,
+            move.name,
+        )
+
+        expected_damage = 30 if expected_critical else 20
+
+        assert result.accepted
+        assert result.hit
+        assert result.critical is expected_critical
+        assert result.damage == expected_damage
+        assert target.health.current == target.health.maximum - expected_damage
+        assert actor.super_resource.current == expected_super
+        assert expected_crit_chance >= 0
+
+
+def test_critical_damage_uses_multiplier_and_super_damage_can_crit():
+    actor = SimpleCombatant(
+        moves=(
+            make_move(
+                name="super crit",
+                resource_type=ResourceType.SUPER,
+                resource_cost=100,
+                power=20,
+                scales_with=(ScalingAttribute.NONE,),
+            ),
+        ),
+        effective_stats={
+            "constitution": 8,
+            "spirit": 8,
+            "intelligence": 8,
+            "strength": 8,
+            "dexterity": 10,
+            "intuition": 100,
+        },
+    )
+    actor.super_resource.gain(100)
+    target = no_mitigation_target()
+
+    result = CombatResolver(rng=ScriptedRng(1, 15)).resolve_move(
+        actor,
+        target,
+        "super crit",
+    )
+
+    assert result.accepted
+    assert result.hit
+    assert result.critical is True
+    assert result.damage == 30
+    assert target.health.current == target.health.maximum - 30
+    assert actor.super_resource.current == 0
+
+
+def test_missed_damage_move_does_not_roll_crit():
+    actor = SimpleCombatant(
+        moves=(make_move(name="misses", accuracy=5, scales_with=(ScalingAttribute.NONE,)),),
+        effective_stats={
+            "constitution": 8,
+            "spirit": 8,
+            "intelligence": 8,
+            "strength": 8,
+            "dexterity": 10,
+            "intuition": 100,
+        },
+    )
+    target = no_mitigation_target()
+    rng = ScriptedRng(100)
+
+    result = CombatResolver(rng=rng).resolve_move(actor, target, "misses")
+
+    assert result.accepted
+    assert not result.hit
+    assert result.critical is False
+    assert result.damage == 0
+    assert rng.calls == [(1, 100)]
+
+
+def test_healing_defend_and_rejected_actions_do_not_roll_crit():
+    heal_actor = SimpleCombatant(
+        moves=(
+            make_move(
+                name="heal",
+                kind=MoveKind.HEALING,
+                damage_type=DamageType.HEALING,
+                target=TargetType.SELF,
+                scales_with=(ScalingAttribute.NONE,),
+            ),
+        ),
+        effective_stats={
+            "constitution": 8,
+            "spirit": 8,
+            "intelligence": 8,
+            "strength": 8,
+            "dexterity": 10,
+            "intuition": 100,
+        },
+        can_defend=True,
+    )
+    heal_actor.health.take_damage(10)
+    heal_rng = ScriptedRng(1)
+
+    healing = CombatResolver(rng=heal_rng).resolve_move(heal_actor, heal_actor, "heal")
+
+    assert healing.accepted
+    assert healing.critical is False
+    assert heal_rng.calls == [(1, 100)]
+
+    combat_state = CombatState()
+    defend_result = CombatResolver(rng=ScriptedRng(1)).resolve_defend(heal_actor, combat_state)
+
+    assert defend_result.accepted
+    assert defend_result.critical is False
+
+    rejected_rng = ScriptedRng(1)
+    rejected = CombatResolver(rng=rejected_rng).resolve_move(
+        heal_actor,
+        no_mitigation_target(),
+        "missing",
+    )
+
+    assert not rejected.accepted
+    assert rejected.critical is False
+    assert rejected_rng.calls == []
+
+
 def test_accuracy_uses_randint_one_to_one_hundred_and_roll_less_or_equal_hits():
     hit_actor = PlayerState(Brawler())
     target = EnemyState(Goblin())
@@ -522,7 +678,7 @@ def test_accuracy_uses_randint_one_to_one_hundred_and_roll_less_or_equal_hits():
     result = CombatResolver(rng=rng).resolve_move(hit_actor, target, "Crestgrave Reaping")
 
     assert result.hit
-    assert rng.calls == [(1, 100)]
+    assert rng.calls == [(1, 100), (1, 100)]
 
     miss_actor = PlayerState(Brawler())
     rng = ScriptedRng(93)
@@ -534,7 +690,7 @@ def test_accuracy_uses_randint_one_to_one_hundred_and_roll_less_or_equal_hits():
     )
 
     assert result.hit
-    assert rng.calls == [(1, 100)]
+    assert rng.calls == [(1, 100), (1, 100)]
 
 
 def test_dexterity_accuracy_and_dodge_adjust_final_hit_chance():
@@ -728,11 +884,11 @@ def test_accuracy_zero_and_one_hundred_still_roll_exactly_once():
 
     rng = ScriptedRng(95)
     assert CombatResolver(rng=rng).resolve_move(actor, EnemyState(Goblin()), certain.name).hit
-    assert rng.calls == [(1, 100)]
+    assert rng.calls == [(1, 100), (1, 100)]
 
     rng = ScriptedRng(1)
     assert CombatResolver(rng=rng).resolve_move(actor, EnemyState(Goblin()), impossible.name).hit
-    assert rng.calls == [(1, 100)]
+    assert rng.calls == [(1, 100), (1, 100)]
 
 
 def combatant_with_primary_stat(move, stat_name, value):

--- a/tests/test_combat_resolver.py
+++ b/tests/test_combat_resolver.py
@@ -432,6 +432,43 @@ def test_super_generation_clamps_occurs_after_landed_damage_hit():
     assert actor.super_resource.current == 100
 
 
+def test_intuition_scales_super_gain_from_landed_non_super_damage_hits():
+    examples = (
+        (10, 10),
+        (20, 11),
+        (40, 12),
+        (60, 14),
+        (100, 16),
+    )
+
+    for intuition, expected_gain in examples:
+        move = make_move(
+            name=f"intuition {intuition}",
+            scales_with=(ScalingAttribute.NONE,),
+        )
+        actor = SimpleCombatant(
+            moves=(move,),
+            effective_stats={
+                "constitution": 8,
+                "spirit": 8,
+                "intelligence": 8,
+                "strength": 8,
+                "dexterity": 10,
+                "intuition": intuition,
+            },
+        )
+
+        result = CombatResolver(rng=ScriptedRng(1)).resolve_move(
+            actor,
+            no_mitigation_target(),
+            move.name,
+        )
+
+        assert result.accepted
+        assert result.hit
+        assert actor.super_resource.current == expected_gain
+
+
 def test_healing_action_does_not_generate_super():
     healer = PlayerState(Brawler())
     healer.health.take_damage(10)
@@ -456,11 +493,21 @@ def test_healing_action_does_not_generate_super():
 
 
 def test_battle_ending_damage_still_generates_super():
-    actor = PlayerState(Brawler())
+    actor = SimpleCombatant(
+        moves=(make_move(name="battle ending"),),
+        effective_stats={
+            "constitution": 8,
+            "spirit": 8,
+            "intelligence": 8,
+            "strength": 8,
+            "dexterity": 10,
+            "intuition": 10,
+        },
+    )
     target = EnemyState(Goblin())
     target.health.take_damage(59)
 
-    result = CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, target, "Crestgrave Reaping")
+    result = CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, target, "battle ending")
 
     assert result.damage == 1
     assert not target.is_alive()
@@ -1421,7 +1468,36 @@ def test_enemy_with_explicit_super_capability_generates_super():
 
     assert result.accepted
     assert actor.generates_super
-    assert actor.super_resource.current == 10
+    assert actor.super_resource.current == 9
+
+
+def test_super_capable_enemy_super_gain_scales_with_intuition():
+    move = make_move(
+        name="super gain strike",
+        scales_with=(ScalingAttribute.NONE,),
+    )
+    actor = SimpleCombatant(
+        moves=(move,),
+        effective_stats={
+            "constitution": 8,
+            "spirit": 8,
+            "intelligence": 8,
+            "strength": 8,
+            "dexterity": 10,
+            "intuition": 60,
+        },
+    )
+    target = no_mitigation_target()
+
+    result = CombatResolver(rng=ScriptedRng(1)).resolve_move(
+        actor,
+        target,
+        move.name,
+    )
+
+    assert result.accepted
+    assert actor.generates_super
+    assert actor.super_resource.current == 14
 
 
 def test_every_ordinary_goblin_move_is_resolver_supported_without_filtering():

--- a/tests/test_combat_resolver.py
+++ b/tests/test_combat_resolver.py
@@ -22,7 +22,12 @@ class ScriptedRng:
 
 
 class SimpleCombatant:
-    def __init__(self, moves=(), generates_super=True, can_defend=False):
+    def __init__(
+            self,
+            moves=(),
+            generates_super=True,
+            can_defend=False,
+            effective_stats=None):
         self.display_name = "Simple"
         self.health = PlayerState(Brawler()).health
         self.mana_resource = PlayerState(Brawler()).mana_resource
@@ -30,20 +35,21 @@ class SimpleCombatant:
         self.generates_super = generates_super
         self.can_defend = can_defend
         self._combat_moves = tuple(moves)
-
-    @property
-    def combat_moves(self):
-        return self._combat_moves
-
-    def effective_stat(self, name):
-        return {
+        self._effective_stats = effective_stats or {
             "constitution": 8,
             "spirit": 8,
             "intelligence": 8,
             "strength": 8,
             "dexterity": 8,
             "intuition": 8,
-        }[name]
+        }
+
+    @property
+    def combat_moves(self):
+        return self._combat_moves
+
+    def effective_stat(self, name):
+        return self._effective_stats[name]
 
     def defend_reduction_percent(self, damage_type):
         return 0
@@ -126,8 +132,8 @@ def test_owned_canonical_move_resolves_and_foreign_or_unknown_moves_are_rejected
     assert result.accepted
     assert result.hit
     assert result.move_name == "Crestgrave Reaping"
-    assert result.damage == 27
-    assert target.health.current == 33
+    assert result.damage == 10
+    assert target.health.current == 50
     assert actor.super_resource.current == 10
     assert rng.calls == [(1, 100)]
 
@@ -421,8 +427,8 @@ def test_super_generation_clamps_occurs_after_resolution_and_includes_zero_heali
 
     result = CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, target, "Crestgrave Reaping")
 
-    assert result.damage == 27
-    assert target.health.current == 33
+    assert result.damage == 10
+    assert target.health.current == 50
     assert actor.super_resource.current == 100
 
     healer = PlayerState(Brawler())
@@ -495,7 +501,133 @@ def test_accuracy_zero_and_one_hundred_still_roll_exactly_once():
     assert rng.calls == [(1, 100)]
 
 
-def test_scaling_uses_effective_stat_mean_weapon_bonuses_and_does_not_mutate_stats():
+def combatant_with_primary_stat(move, stat_name, value):
+    effective_stats = {
+        "constitution": 1,
+        "spirit": 1,
+        "intelligence": 10,
+        "strength": 10,
+        "dexterity": 10,
+        "intuition": 10,
+    }
+    effective_stats[stat_name] = value
+    return SimpleCombatant(moves=(move,), effective_stats=effective_stats)
+
+
+def no_mitigation_target():
+    return SimpleCombatant(
+        effective_stats={
+            "constitution": 1,
+            "spirit": 1,
+            "intelligence": 10,
+            "strength": 10,
+            "dexterity": 10,
+            "intuition": 10,
+        }
+    )
+
+
+def test_damage_output_uses_basis_point_primary_stat_scaling():
+    examples = (
+        (ScalingAttribute.STRENGTH, "strength", 10, 20),
+        (ScalingAttribute.STRENGTH, "strength", 20, 25),
+        (ScalingAttribute.DEXTERITY, "dexterity", 20, 25),
+        (ScalingAttribute.INTELLIGENCE, "intelligence", 20, 25),
+        (ScalingAttribute.STRENGTH, "strength", 5, 17),
+    )
+
+    for attribute, stat_name, stat_value, expected_damage in examples:
+        move = make_move(
+            name=f"{attribute.value} {stat_value}",
+            power=20,
+            scales_with=(attribute,),
+        )
+        actor = combatant_with_primary_stat(move, stat_name, stat_value)
+
+        result = CombatResolver(rng=ScriptedRng(1)).resolve_move(
+            actor,
+            no_mitigation_target(),
+            move.name,
+        )
+
+        assert result.damage == expected_damage
+
+
+def test_damage_output_averages_supported_scaling_and_ignores_unsupported_attributes():
+    supported_average = make_move(
+        name="supported average",
+        power=20,
+        scales_with=(ScalingAttribute.STRENGTH, ScalingAttribute.DEXTERITY),
+    )
+    supported_actor = SimpleCombatant(
+        moves=(supported_average,),
+        effective_stats={
+            "constitution": 1,
+            "spirit": 1,
+            "intelligence": 10,
+            "strength": 20,
+            "dexterity": 10,
+            "intuition": 10,
+        },
+    )
+
+    assert (
+        CombatResolver(rng=ScriptedRng(1)).resolve_move(
+            supported_actor,
+            no_mitigation_target(),
+            supported_average.name,
+        ).damage
+        == 22
+    )
+
+    intelligence_and_spirit = make_move(
+        name="intelligence and spirit",
+        power=20,
+        scales_with=(ScalingAttribute.INTELLIGENCE, ScalingAttribute.SPIRIT),
+    )
+    intelligence_actor = SimpleCombatant(
+        moves=(intelligence_and_spirit,),
+        effective_stats={
+            "constitution": 1,
+            "spirit": 1,
+            "intelligence": 20,
+            "strength": 10,
+            "dexterity": 10,
+            "intuition": 10,
+        },
+    )
+
+    assert (
+        CombatResolver(rng=ScriptedRng(1)).resolve_move(
+            intelligence_actor,
+            no_mitigation_target(),
+            intelligence_and_spirit.name,
+        ).damage
+        == 25
+    )
+
+    for scales_with in (
+            (ScalingAttribute.SPIRIT,),
+            (ScalingAttribute.NONE,),
+    ):
+        move = make_move(
+            name=f"unsupported {scales_with[0].value}",
+            power=20,
+            scales_with=scales_with,
+        )
+        actor = SimpleCombatant(moves=(move,))
+
+        assert (
+            CombatResolver(rng=ScriptedRng(1)).resolve_move(
+                actor,
+                no_mitigation_target(),
+                move.name,
+            ).damage
+            == 20
+        )
+
+
+def test_damage_scaling_uses_effective_stat_weapon_bonuses_and_does_not_mutate_stats():
     actor = PlayerState(Brawler())
     target = EnemyState(Goblin())
     permanent_before = actor.character.permanent_stats.as_dict()
@@ -519,7 +651,7 @@ def test_scaling_uses_effective_stat_mean_weapon_bonuses_and_does_not_mutate_sta
 
     result = CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, target, hybrid.name)
 
-    assert result.damage == 24
+    assert result.damage == 11
     assert actor.character.permanent_stats.as_dict() == permanent_before
 
     target = EnemyState(Goblin())
@@ -556,10 +688,10 @@ def test_damage_formulas_for_physical_magical_hybrid_minimum_and_overkill():
             target,
             "Crestgrave Reaping",
         ).damage
-        == 27
+        == 10
     )
-    assert CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, EnemyState(Goblin()), magical.name).damage == 15
-    assert CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, EnemyState(Goblin()), hybrid.name).damage == 24
+    assert CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, EnemyState(Goblin()), magical.name).damage == 8
+    assert CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, EnemyState(Goblin()), hybrid.name).damage == 11
 
     weak = add_move(
         actor,
@@ -605,8 +737,8 @@ def test_non_defended_resolver_results_remain_unchanged_with_optional_combat_sta
         combat_state=CombatState(),
     )
 
-    assert without_state.damage == 27
-    assert with_state.damage == 27
+    assert without_state.damage == 10
+    assert with_state.damage == 10
     assert without_state.hit == with_state.hit
 
 
@@ -657,7 +789,7 @@ def test_defended_damage_uses_player_stat_scaled_reductions_and_minimum_one():
         combat_state=combat_state,
     )
 
-    assert result.damage == 5
+    assert result.damage == 2
 
     magical = make_move(
         name="magic",
@@ -924,8 +1056,8 @@ def test_equivalent_player_and_enemy_runtime_combatants_resolve_without_type_bra
 
     assert player_result.accepted
     assert enemy_result.accepted
-    assert player_result.damage == 27
-    assert enemy_result.damage == 8
+    assert player_result.damage == 10
+    assert enemy_result.damage == 3
     assert player.super_resource.current == 10
     assert enemy.super_resource.current == 0
 

--- a/tests/test_combat_resolver.py
+++ b/tests/test_combat_resolver.py
@@ -354,7 +354,7 @@ def test_mana_spending_affordability_and_miss_behavior():
     assert result.resource_spent == 5
     assert actor.mana_resource.current == 41
     assert target.health.current == target.health.maximum
-    assert actor.super_resource.current == 10
+    assert actor.super_resource.current == 0
 
     actor = PlayerState(Brawler())
     target = EnemyState(Goblin())
@@ -420,7 +420,7 @@ def test_super_move_does_not_gain_non_super_action_bonus():
     assert actor.super_resource.current == 0
 
 
-def test_super_generation_clamps_occurs_after_resolution_and_includes_zero_healing():
+def test_super_generation_clamps_occurs_after_landed_damage_hit():
     actor = PlayerState(Brawler())
     target = EnemyState(Goblin())
     actor.super_resource.gain(95)
@@ -431,7 +431,10 @@ def test_super_generation_clamps_occurs_after_resolution_and_includes_zero_heali
     assert target.health.current == 50
     assert actor.super_resource.current == 100
 
+
+def test_healing_action_does_not_generate_super():
     healer = PlayerState(Brawler())
+    healer.health.take_damage(10)
     heal = add_move(
         healer,
         make_move(
@@ -448,8 +451,8 @@ def test_super_generation_clamps_occurs_after_resolution_and_includes_zero_heali
     result = CombatResolver(rng=ScriptedRng(1)).resolve_move(healer, healer, heal.name)
 
     assert result.accepted
-    assert result.healing == 0
-    assert healer.super_resource.current == 10
+    assert result.healing == 10
+    assert healer.super_resource.current == 0
 
 
 def test_battle_ending_damage_still_generates_super():
@@ -958,7 +961,7 @@ def test_rejected_action_does_not_consume_defend_or_advance_turn():
     assert combat_state.turn_count == 0
 
 
-def test_resolve_defend_validation_mutation_and_player_super_gain():
+def test_resolve_defend_validation_mutation_and_no_super_gain():
     actor = PlayerState(Brawler())
     combat_state = CombatState()
 
@@ -974,7 +977,7 @@ def test_resolve_defend_validation_mutation_and_player_super_gain():
     assert result.reason is None
     assert combat_state.is_defending(actor)
     assert combat_state.turn_count == 0
-    assert actor.super_resource.current == 10
+    assert actor.super_resource.current == 0
 
 
 def test_rejected_defend_does_not_mutate_state_or_gain_super():
@@ -1001,7 +1004,7 @@ def test_rejected_defend_does_not_mutate_state_or_gain_super():
     assert actor.super_resource.current == 0
 
 
-def test_enemy_defend_capability_and_super_generation_are_explicit():
+def test_enemy_defend_capability_does_not_generate_super():
     goblin = EnemyState(Goblin())
     combat_state = CombatState()
 
@@ -1040,7 +1043,7 @@ def test_enemy_defend_capability_and_super_generation_are_explicit():
     )
 
     assert result.accepted
-    assert defender_with_super.super_resource.current == 10
+    assert defender_with_super.super_resource.current == 0
 
 
 def test_equivalent_player_and_enemy_runtime_combatants_resolve_without_type_branches():

--- a/tests/test_combat_resolver.py
+++ b/tests/test_combat_resolver.py
@@ -486,25 +486,31 @@ def test_accuracy_uses_randint_one_to_one_hundred_and_roll_less_or_equal_hits():
         "Crestgrave Reaping",
     )
 
-    assert not result.hit
+    assert result.hit
     assert rng.calls == [(1, 100)]
 
 
-def test_dexterity_accuracy_bonus_applies_to_final_hit_chance():
+def test_dexterity_accuracy_and_dodge_adjust_final_hit_chance():
     examples = (
-        (10, 50, 50, True),
-        (10, 50, 51, False),
-        (20, 50, 54, True),
-        (20, 50, 55, False),
-        (40, 50, 60, True),
-        (40, 50, 61, False),
-        (100, 70, 90, True),
-        (100, 70, 91, False),
+        (10, 10, 50, 50, True),
+        (10, 10, 50, 51, False),
+        (20, 10, 50, 54, True),
+        (20, 10, 50, 55, False),
+        (40, 10, 50, 60, True),
+        (40, 10, 50, 61, False),
+        (10, 20, 50, 48, True),
+        (10, 20, 50, 49, False),
+        (10, 40, 50, 44, True),
+        (10, 40, 50, 45, False),
+        (100, 10, 70, 90, True),
+        (100, 10, 70, 91, False),
+        (40, 20, 50, 58, True),
+        (40, 20, 50, 59, False),
     )
 
-    for dexterity, accuracy, roll, expected_hit in examples:
+    for actor_dexterity, target_dexterity, accuracy, roll, expected_hit in examples:
         move = make_move(
-            name=f"dex {dexterity} acc {accuracy}",
+            name=f"actor {actor_dexterity} target {target_dexterity} acc {accuracy}",
             accuracy=accuracy,
             scales_with=(ScalingAttribute.NONE,),
         )
@@ -515,21 +521,31 @@ def test_dexterity_accuracy_bonus_applies_to_final_hit_chance():
                 "spirit": 8,
                 "intelligence": 8,
                 "strength": 8,
-                "dexterity": dexterity,
+                "dexterity": actor_dexterity,
                 "intuition": 8,
+            },
+        )
+        target = SimpleCombatant(
+            effective_stats={
+                "constitution": 1,
+                "spirit": 1,
+                "intelligence": 10,
+                "strength": 10,
+                "dexterity": target_dexterity,
+                "intuition": 10,
             },
         )
 
         result = CombatResolver(rng=ScriptedRng(roll)).resolve_move(
             actor,
-            no_mitigation_target(),
+            target,
             move.name,
         )
 
         assert result.hit is expected_hit
 
 
-def test_dexterity_accuracy_bonus_caps_final_hit_chance_at_ninety_five():
+def test_final_hit_chance_caps_at_ninety_five_with_accuracy_and_dodge():
     move = make_move(
         name="cap test",
         accuracy=90,
@@ -546,15 +562,25 @@ def test_dexterity_accuracy_bonus_caps_final_hit_chance_at_ninety_five():
             "intuition": 8,
         },
     )
+    target = SimpleCombatant(
+        effective_stats={
+            "constitution": 1,
+            "spirit": 1,
+            "intelligence": 10,
+            "strength": 10,
+            "dexterity": 10,
+            "intuition": 10,
+        },
+    )
 
     hit_result = CombatResolver(rng=ScriptedRng(95)).resolve_move(
         actor,
-        no_mitigation_target(),
+        target,
         move.name,
     )
     miss_result = CombatResolver(rng=ScriptedRng(96)).resolve_move(
         actor,
-        no_mitigation_target(),
+        target,
         move.name,
     )
 
@@ -562,9 +588,52 @@ def test_dexterity_accuracy_bonus_caps_final_hit_chance_at_ninety_five():
     assert not miss_result.hit
 
 
-def test_low_dexterity_negative_accuracy_bonus_is_preserved():
+def test_final_hit_chance_floors_at_five():
     move = make_move(
-        name="low dex test",
+        name="floor test",
+        accuracy=0,
+        scales_with=(ScalingAttribute.NONE,),
+    )
+    actor = SimpleCombatant(
+        moves=(move,),
+        effective_stats={
+            "constitution": 8,
+            "spirit": 8,
+            "intelligence": 8,
+            "strength": 8,
+            "dexterity": 10,
+            "intuition": 8,
+        },
+    )
+    target = SimpleCombatant(
+        effective_stats={
+            "constitution": 1,
+            "spirit": 1,
+            "intelligence": 10,
+            "strength": 10,
+            "dexterity": 100,
+            "intuition": 10,
+        },
+    )
+
+    hit_result = CombatResolver(rng=ScriptedRng(5)).resolve_move(
+        actor,
+        target,
+        move.name,
+    )
+    miss_result = CombatResolver(rng=ScriptedRng(6)).resolve_move(
+        actor,
+        target,
+        move.name,
+    )
+
+    assert hit_result.hit
+    assert not miss_result.hit
+
+
+def test_low_target_dexterity_negative_dodge_bonus_is_preserved_before_clamp():
+    move = make_move(
+        name="low target dex test",
         accuracy=50,
         scales_with=(ScalingAttribute.NONE,),
     )
@@ -575,19 +644,29 @@ def test_low_dexterity_negative_accuracy_bonus_is_preserved():
             "spirit": 8,
             "intelligence": 8,
             "strength": 8,
-            "dexterity": 5,
+            "dexterity": 10,
             "intuition": 8,
         },
     )
+    target = SimpleCombatant(
+        effective_stats={
+            "constitution": 1,
+            "spirit": 1,
+            "intelligence": 10,
+            "strength": 10,
+            "dexterity": 5,
+            "intuition": 10,
+        },
+    )
 
-    hit_result = CombatResolver(rng=ScriptedRng(48)).resolve_move(
+    hit_result = CombatResolver(rng=ScriptedRng(51)).resolve_move(
         actor,
-        no_mitigation_target(),
+        target,
         move.name,
     )
-    miss_result = CombatResolver(rng=ScriptedRng(49)).resolve_move(
+    miss_result = CombatResolver(rng=ScriptedRng(52)).resolve_move(
         actor,
-        no_mitigation_target(),
+        target,
         move.name,
     )
 
@@ -605,7 +684,7 @@ def test_accuracy_zero_and_one_hundred_still_roll_exactly_once():
     assert rng.calls == [(1, 100)]
 
     rng = ScriptedRng(1)
-    assert not CombatResolver(rng=rng).resolve_move(actor, EnemyState(Goblin()), impossible.name).hit
+    assert CombatResolver(rng=rng).resolve_move(actor, EnemyState(Goblin()), impossible.name).hit
     assert rng.calls == [(1, 100)]
 
 
@@ -1144,7 +1223,7 @@ def test_accepted_action_completion_consumes_opposing_defend_for_hits_misses_hea
         combat_state=combat_state,
     )
     assert miss.accepted
-    assert not miss.hit
+    assert miss.hit
     combat_state.complete_accepted_action(attacker, opposing_combatants=(defender,))
     assert not combat_state.is_defending(defender)
 

--- a/tests/test_combat_resolver.py
+++ b/tests/test_combat_resolver.py
@@ -346,25 +346,25 @@ def test_mana_spending_affordability_and_miss_behavior():
     result = CombatResolver(rng=ScriptedRng(100)).resolve_move(
         actor,
         target,
-        "Ironwake Dismemberment",
+        "Ghalmour Compression",
     )
 
     assert result.accepted
     assert not result.hit
-    assert result.resource_spent == 3
-    assert actor.mana_resource.current == 43
+    assert result.resource_spent == 5
+    assert actor.mana_resource.current == 41
     assert target.health.current == target.health.maximum
     assert actor.super_resource.current == 10
 
     actor = PlayerState(Brawler())
     target = EnemyState(Goblin())
-    actor.mana_resource.spend(44)
+    actor.mana_resource.spend(42)
     rng = ScriptedRng(1)
 
-    result = CombatResolver(rng=rng).resolve_move(actor, target, "Ironwake Dismemberment")
+    result = CombatResolver(rng=rng).resolve_move(actor, target, "Ghalmour Compression")
 
     assert result.reason == "insufficient_mana"
-    assert actor.mana_resource.current == 2
+    assert actor.mana_resource.current == 4
     assert actor.super_resource.current == 0
     assert rng.calls == []
 

--- a/tests/test_combat_resolver.py
+++ b/tests/test_combat_resolver.py
@@ -490,12 +490,117 @@ def test_accuracy_uses_randint_one_to_one_hundred_and_roll_less_or_equal_hits():
     assert rng.calls == [(1, 100)]
 
 
+def test_dexterity_accuracy_bonus_applies_to_final_hit_chance():
+    examples = (
+        (10, 50, 50, True),
+        (10, 50, 51, False),
+        (20, 50, 54, True),
+        (20, 50, 55, False),
+        (40, 50, 60, True),
+        (40, 50, 61, False),
+        (100, 70, 90, True),
+        (100, 70, 91, False),
+    )
+
+    for dexterity, accuracy, roll, expected_hit in examples:
+        move = make_move(
+            name=f"dex {dexterity} acc {accuracy}",
+            accuracy=accuracy,
+            scales_with=(ScalingAttribute.NONE,),
+        )
+        actor = SimpleCombatant(
+            moves=(move,),
+            effective_stats={
+                "constitution": 8,
+                "spirit": 8,
+                "intelligence": 8,
+                "strength": 8,
+                "dexterity": dexterity,
+                "intuition": 8,
+            },
+        )
+
+        result = CombatResolver(rng=ScriptedRng(roll)).resolve_move(
+            actor,
+            no_mitigation_target(),
+            move.name,
+        )
+
+        assert result.hit is expected_hit
+
+
+def test_dexterity_accuracy_bonus_caps_final_hit_chance_at_ninety_five():
+    move = make_move(
+        name="cap test",
+        accuracy=90,
+        scales_with=(ScalingAttribute.NONE,),
+    )
+    actor = SimpleCombatant(
+        moves=(move,),
+        effective_stats={
+            "constitution": 8,
+            "spirit": 8,
+            "intelligence": 8,
+            "strength": 8,
+            "dexterity": 100,
+            "intuition": 8,
+        },
+    )
+
+    hit_result = CombatResolver(rng=ScriptedRng(95)).resolve_move(
+        actor,
+        no_mitigation_target(),
+        move.name,
+    )
+    miss_result = CombatResolver(rng=ScriptedRng(96)).resolve_move(
+        actor,
+        no_mitigation_target(),
+        move.name,
+    )
+
+    assert hit_result.hit
+    assert not miss_result.hit
+
+
+def test_low_dexterity_negative_accuracy_bonus_is_preserved():
+    move = make_move(
+        name="low dex test",
+        accuracy=50,
+        scales_with=(ScalingAttribute.NONE,),
+    )
+    actor = SimpleCombatant(
+        moves=(move,),
+        effective_stats={
+            "constitution": 8,
+            "spirit": 8,
+            "intelligence": 8,
+            "strength": 8,
+            "dexterity": 5,
+            "intuition": 8,
+        },
+    )
+
+    hit_result = CombatResolver(rng=ScriptedRng(48)).resolve_move(
+        actor,
+        no_mitigation_target(),
+        move.name,
+    )
+    miss_result = CombatResolver(rng=ScriptedRng(49)).resolve_move(
+        actor,
+        no_mitigation_target(),
+        move.name,
+    )
+
+    assert hit_result.hit
+    assert not miss_result.hit
+
+
 def test_accuracy_zero_and_one_hundred_still_roll_exactly_once():
     actor = PlayerState(Brawler())
     certain = add_move(actor, make_move(name="certain", accuracy=100))
     impossible = add_move(actor, make_move(name="impossible", accuracy=0))
 
-    rng = ScriptedRng(100)
+    rng = ScriptedRng(95)
     assert CombatResolver(rng=rng).resolve_move(actor, EnemyState(Goblin()), certain.name).hit
     assert rng.calls == [(1, 100)]
 

--- a/tests/test_combat_resolver.py
+++ b/tests/test_combat_resolver.py
@@ -132,8 +132,8 @@ def test_owned_canonical_move_resolves_and_foreign_or_unknown_moves_are_rejected
     assert result.accepted
     assert result.hit
     assert result.move_name == "Crestgrave Reaping"
-    assert result.damage == 10
-    assert target.health.current == 50
+    assert result.damage == 11
+    assert target.health.current == 49
     assert actor.super_resource.current == 10
     assert rng.calls == [(1, 100)]
 
@@ -427,8 +427,8 @@ def test_super_generation_clamps_occurs_after_landed_damage_hit():
 
     result = CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, target, "Crestgrave Reaping")
 
-    assert result.damage == 10
-    assert target.health.current == 50
+    assert result.damage == 11
+    assert target.health.current == 49
     assert actor.super_resource.current == 100
 
 
@@ -660,7 +660,7 @@ def test_damage_scaling_uses_effective_stat_weapon_bonuses_and_does_not_mutate_s
     target = EnemyState(Goblin())
     result = CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, target, no_scale.name)
 
-    assert result.damage == 10
+    assert result.damage == 11
 
 
 def test_damage_formulas_for_physical_magical_hybrid_minimum_and_overkill():
@@ -691,7 +691,7 @@ def test_damage_formulas_for_physical_magical_hybrid_minimum_and_overkill():
             target,
             "Crestgrave Reaping",
         ).damage
-        == 10
+        == 11
     )
     assert CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, EnemyState(Goblin()), magical.name).damage == 8
     assert CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, EnemyState(Goblin()), hybrid.name).damage == 11
@@ -740,9 +740,115 @@ def test_non_defended_resolver_results_remain_unchanged_with_optional_combat_sta
         combat_state=CombatState(),
     )
 
-    assert without_state.damage == 10
-    assert with_state.damage == 10
+    assert without_state.damage == 11
+    assert with_state.damage == 11
     assert without_state.hit == with_state.hit
+
+
+def test_strength_physical_negation_applies_only_to_incoming_physical_damage():
+    actor = SimpleCombatant(
+        moves=(
+            make_move(
+                name="physical",
+                power=20,
+                damage_type=DamageType.PHYSICAL,
+                scales_with=(ScalingAttribute.NONE,),
+            ),
+            make_move(
+                name="magical",
+                power=20,
+                damage_type=DamageType.MAGICAL,
+                scales_with=(ScalingAttribute.NONE,),
+            ),
+        ),
+    )
+
+    examples = (
+        (10, 20),
+        (20, 19),
+        (40, 17),
+        (100, 14),
+    )
+
+    for strength, expected_physical_damage in examples:
+        target = SimpleCombatant(
+            effective_stats={
+                "constitution": 1,
+                "spirit": 1,
+                "intelligence": 8,
+                "strength": strength,
+                "dexterity": 8,
+                "intuition": 8,
+            },
+        )
+
+        physical_result = CombatResolver(rng=ScriptedRng(1)).resolve_move(
+            actor,
+            target,
+            "physical",
+        )
+        magical_result = CombatResolver(rng=ScriptedRng(1)).resolve_move(
+            actor,
+            target,
+            "magical",
+        )
+
+        assert physical_result.damage == expected_physical_damage
+        assert magical_result.damage == 20
+
+
+def test_low_strength_targets_can_take_extra_physical_damage_per_helper_contract():
+    actor = SimpleCombatant(
+        moves=(
+            make_move(
+                name="physical",
+                power=20,
+                damage_type=DamageType.PHYSICAL,
+                scales_with=(ScalingAttribute.NONE,),
+            ),
+        ),
+    )
+    target = SimpleCombatant(
+        effective_stats={
+            "constitution": 1,
+            "spirit": 1,
+            "intelligence": 8,
+            "strength": 3,
+            "dexterity": 8,
+            "intuition": 8,
+        },
+    )
+
+    result = CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, target, "physical")
+
+    assert result.damage == 21
+
+
+def test_strength_physical_negation_preserves_minimum_landed_damage_of_one():
+    actor = SimpleCombatant(
+        moves=(
+            make_move(
+                name="tap",
+                power=0,
+                damage_type=DamageType.PHYSICAL,
+                scales_with=(ScalingAttribute.NONE,),
+            ),
+        ),
+    )
+    target = SimpleCombatant(
+        effective_stats={
+            "constitution": 100,
+            "spirit": 8,
+            "intelligence": 8,
+            "strength": 100,
+            "dexterity": 8,
+            "intuition": 8,
+        },
+    )
+
+    result = CombatResolver(rng=ScriptedRng(1)).resolve_move(actor, target, "tap")
+
+    assert result.damage == 1
 
 
 def test_defended_damage_uses_enemy_fixed_reductions_and_floors_reduction_amount():
@@ -750,7 +856,7 @@ def test_defended_damage_uses_enemy_fixed_reductions_and_floors_reduction_amount
         (DamageType.PHYSICAL, 5, 3),
         (DamageType.MAGICAL, 5, 3),
         (DamageType.HYBRID, 5, 4),
-        (DamageType.PHYSICAL, 20, 10),
+        (DamageType.PHYSICAL, 20, 11),
         (DamageType.MAGICAL, 20, 12),
         (DamageType.HYBRID, 20, 14),
     )
@@ -777,6 +883,37 @@ def test_defended_damage_uses_enemy_fixed_reductions_and_floors_reduction_amount
         )
 
         assert result.damage == expected_damage
+
+
+def test_defend_still_reduces_damage_after_strength_negation():
+    move = make_move(
+        name="physical 20",
+        power=20,
+        damage_type=DamageType.PHYSICAL,
+        scales_with=(ScalingAttribute.NONE,),
+    )
+    actor = SimpleCombatant(moves=(move,))
+    target = create_enemy_state_with_capabilities(
+        capabilities=(EnemyCapability.BASIC_ATTACKS, EnemyCapability.DEFEND),
+    )
+
+    without_defend = CombatResolver(rng=ScriptedRng(1)).resolve_move(
+        actor,
+        target,
+        move.name,
+    )
+
+    combat_state = CombatState()
+    combat_state.activate_defend(target)
+    with_defend = CombatResolver(rng=ScriptedRng(1)).resolve_move(
+        actor,
+        target,
+        move.name,
+        combat_state=combat_state,
+    )
+
+    assert without_defend.damage == 21
+    assert with_defend.damage == 11
 
 
 def test_defended_damage_uses_player_stat_scaled_reductions_and_minimum_one():
@@ -1059,7 +1196,7 @@ def test_equivalent_player_and_enemy_runtime_combatants_resolve_without_type_bra
 
     assert player_result.accepted
     assert enemy_result.accepted
-    assert player_result.damage == 10
+    assert player_result.damage == 11
     assert enemy_result.damage == 3
     assert player.super_resource.current == 10
     assert enemy.super_resource.current == 0

--- a/tests/test_combatant_contract.py
+++ b/tests/test_combatant_contract.py
@@ -43,8 +43,8 @@ def test_shared_inspection_works_without_type_branches():
     enemy_info = inspect_combatant(enemy_state)
 
     assert player_info["display_name"] == "Brawler"
-    assert player_info["health"] == (60, 60)
-    assert player_info["mana"] == (10, 10)
+    assert player_info["health"] == (116, 116)
+    assert player_info["mana"] == (46, 46)
     assert player_info["super"] == (0, 100)
     assert player_info["generates_super"] is True
     assert player_info["can_defend"] is True

--- a/tests/test_move_result.py
+++ b/tests/test_move_result.py
@@ -16,6 +16,7 @@ def create_result(**overrides):
         "healing": 0,
         "statuses_applied": ("burn",),
         "reason": None,
+        "critical": False,
     }
     values.update(overrides)
     return MoveResult(**values)
@@ -26,6 +27,7 @@ def test_valid_move_result_construction():
 
     assert result.accepted is True
     assert result.hit is True
+    assert result.critical is False
     assert result.move_name == "slash"
     assert result.statuses_applied == ("burn",)
     assert result.reason is None
@@ -43,6 +45,8 @@ def test_boolean_fields_must_be_booleans():
         create_result(accepted=1)
     with pytest.raises(TypeError):
         create_result(hit="yes")
+    with pytest.raises(TypeError):
+        create_result(critical="yes")
 
 
 def test_numeric_fields_are_nonnegative_integers_and_reject_booleans():
@@ -85,3 +89,4 @@ def test_structural_contract_allows_future_valid_action_shapes():
     create_result(accepted=True, hit=False, resource_spent=3, damage=0, healing=0, statuses_applied=())
     create_result(accepted=True, hit=True, resource_spent=2, damage=0, healing=0, statuses_applied=("stun",))
     create_result(accepted=True, hit=True, resource_spent=4, damage=5, healing=5)
+    create_result(accepted=True, hit=True, resource_spent=4, damage=7, healing=0, critical=True)

--- a/tests/test_player_scaling.py
+++ b/tests/test_player_scaling.py
@@ -1,0 +1,167 @@
+import pytest
+
+from app.player import scaling
+
+
+STAT_SCALING_FUNCTIONS = (
+    scaling.maximum_hp_from_constitution,
+    scaling.maximum_mana_from_spirit,
+    scaling.magical_output_bonus_bps_from_intelligence,
+    scaling.physical_output_bonus_bps_from_strength,
+    scaling.physical_negation_bps_from_strength,
+    scaling.physical_output_bonus_bps_from_dexterity,
+    scaling.accuracy_bonus_bps_from_dexterity,
+    scaling.dodge_bonus_bps_from_dexterity,
+    scaling.special_potency_bps_from_intuition,
+    scaling.crit_bonus_bps_from_intuition,
+    scaling.super_gain_bonus_bps_from_intuition,
+    scaling.discovery_bonus_bps_from_intuition,
+    scaling.secured_xp_bonus_bps_from_intuition,
+)
+
+
+def test_stat_scaling_rejects_invalid_stat_types_and_ranges():
+    for function in STAT_SCALING_FUNCTIONS:
+        for invalid_type in (True, False, 1.5, "10", None):
+            with pytest.raises(TypeError):
+                function(invalid_type)
+
+        for invalid_range in (0, 101):
+            with pytest.raises(ValueError):
+                function(invalid_range)
+
+
+def test_resource_scaling_rejects_invalid_level_types_and_ranges():
+    for function in (
+            scaling.maximum_hp_from_constitution,
+            scaling.maximum_mana_from_spirit,
+    ):
+        for invalid_type in (True, False, 1.5, "2", None):
+            with pytest.raises(TypeError):
+                function(10, level=invalid_type)
+
+        with pytest.raises(ValueError):
+            function(10, level=0)
+
+
+def test_constitution_maximum_hp_scaling_milestones():
+    expected = {
+        7: 91,
+        8: 94,
+        10: 100,
+        20: 140,
+        40: 280,
+        60: 380,
+        80: 440,
+        100: 480,
+    }
+
+    for constitution, maximum_hp in expected.items():
+        assert scaling.maximum_hp_from_constitution(constitution) == maximum_hp
+
+
+def test_constitution_maximum_hp_level_growth():
+    assert scaling.maximum_hp_from_constitution(10, level=1) == 100
+    assert scaling.maximum_hp_from_constitution(10, level=2) == 104
+    assert scaling.maximum_hp_from_constitution(10, level=5) == 116
+
+
+def test_spirit_maximum_mana_scaling_milestones():
+    expected = {
+        6: 46,
+        7: 47,
+        10: 50,
+        20: 70,
+        40: 150,
+        60: 210,
+        80: 250,
+        100: 270,
+    }
+
+    for spirit, maximum_mana in expected.items():
+        assert scaling.maximum_mana_from_spirit(spirit) == maximum_mana
+
+
+def test_spirit_maximum_mana_level_growth():
+    assert scaling.maximum_mana_from_spirit(10, level=1) == 50
+    assert scaling.maximum_mana_from_spirit(10, level=2) == 51
+    assert scaling.maximum_mana_from_spirit(10, level=5) == 54
+
+
+@pytest.mark.parametrize(
+    ("function", "expected"),
+    (
+        (
+            scaling.magical_output_bonus_bps_from_intelligence,
+            {10: 0, 20: 2500, 40: 6500, 60: 9500, 80: 11000, 100: 12000},
+        ),
+        (
+            scaling.physical_output_bonus_bps_from_strength,
+            {10: 0, 20: 2500, 40: 6500, 60: 9500, 80: 11000, 100: 12000},
+        ),
+        (
+            scaling.physical_negation_bps_from_strength,
+            {10: 0, 20: 500, 40: 1500, 60: 2400, 80: 3000, 100: 3400},
+        ),
+        (
+            scaling.physical_output_bonus_bps_from_dexterity,
+            {10: 0, 20: 2500, 40: 6500, 60: 9500, 80: 11000, 100: 12000},
+        ),
+        (
+            scaling.accuracy_bonus_bps_from_dexterity,
+            {10: 0, 20: 400, 40: 1000, 60: 1500, 80: 1800, 100: 2000},
+        ),
+        (
+            scaling.dodge_bonus_bps_from_dexterity,
+            {10: 0, 20: 200, 40: 600, 60: 1000, 80: 1300, 100: 1500},
+        ),
+        (
+            scaling.special_potency_bps_from_intuition,
+            {10: 0, 20: 1000, 40: 2500, 60: 3500, 80: 4200, 100: 5000},
+        ),
+        (
+            scaling.crit_bonus_bps_from_intuition,
+            {10: 0, 20: 200, 40: 600, 60: 1000, 80: 1300, 100: 1500},
+        ),
+        (
+            scaling.super_gain_bonus_bps_from_intuition,
+            {10: 0, 20: 1000, 40: 2500, 60: 4000, 80: 5000, 100: 6000},
+        ),
+        (
+            scaling.discovery_bonus_bps_from_intuition,
+            {10: 0, 20: 1000, 40: 2500, 60: 4000, 80: 5500, 100: 7000},
+        ),
+        (
+            scaling.secured_xp_bonus_bps_from_intuition,
+            {10: 0, 20: 100, 40: 400, 60: 700, 80: 1000, 100: 1200},
+        ),
+    ),
+)
+def test_basis_point_scaling_functions_return_exact_milestones(function, expected):
+    for stat, basis_points in expected.items():
+        result = function(stat)
+
+        assert result == basis_points
+        assert isinstance(result, int)
+
+
+def test_basis_point_scaling_interpolates_between_milestones():
+    assert scaling.magical_output_bonus_bps_from_intelligence(15) == 1250
+    assert scaling.magical_output_bonus_bps_from_intelligence(30) == 4500
+    assert scaling.magical_output_bonus_bps_from_intelligence(70) == 10250
+    assert scaling.physical_negation_bps_from_strength(30) == 1000
+    assert scaling.accuracy_bonus_bps_from_dexterity(50) == 1250
+    assert scaling.special_potency_bps_from_intuition(50) == 3000
+    assert scaling.secured_xp_bonus_bps_from_intuition(90) == 1100
+
+
+def test_basis_point_scaling_extrapolates_below_baseline_contract_values():
+    assert scaling.magical_output_bonus_bps_from_intelligence(5) == -1250
+    assert scaling.physical_negation_bps_from_strength(5) == -250
+    assert scaling.accuracy_bonus_bps_from_dexterity(5) == -200
+    assert scaling.dodge_bonus_bps_from_dexterity(5) == -100
+    assert scaling.special_potency_bps_from_intuition(5) == -500
+    assert scaling.crit_bonus_bps_from_intuition(5) == -100
+    assert scaling.super_gain_bonus_bps_from_intuition(5) == -500
+    assert scaling.discovery_bonus_bps_from_intuition(5) == -500
+    assert scaling.secured_xp_bonus_bps_from_intuition(5) == -50

--- a/tests/test_player_snapshot.py
+++ b/tests/test_player_snapshot.py
@@ -43,8 +43,8 @@ def test_default_player_snapshot_has_required_shape():
     }
     assert "charisma" not in snapshot["attributes"]
     assert snapshot["resources"] == {
-        "health": {"current": 60, "maximum": 60},
-        "mana": {"current": 10, "maximum": 10},
+        "health": {"current": 116, "maximum": 116},
+        "mana": {"current": 46, "maximum": 46},
         "super": {"current": 0, "maximum": 100},
     }
     assert snapshot["progression"] == {"level": 1, "exp": 0}
@@ -104,8 +104,8 @@ def test_mutated_resources_progression_gold_and_inventory_are_reflected():
 
     snapshot = player_state.snapshot()
 
-    assert snapshot["resources"]["health"] == {"current": 23, "maximum": 30}
-    assert snapshot["resources"]["mana"] == {"current": 62, "maximum": 70}
+    assert snapshot["resources"]["health"] == {"current": 84, "maximum": 91}
+    assert snapshot["resources"]["mana"] == {"current": 48, "maximum": 56}
     assert snapshot["resources"]["super"] == {"current": 70, "maximum": 100}
     assert snapshot["progression"] == {"level": 3, "exp": 25}
     assert snapshot["gold"] == 15


### PR DESCRIPTION
This PR merges the stat-scaling branch back into master after the post-M8 stat-scaling and hardening pass.

Included work:
- player stat scaling contract
- authored starting stat ownership in player loadouts
- stat-derived player HP and Mana
- combat output scaling
- Strength physical negation
- Dexterity accuracy and dodge
- Intuition Super gain and crit scaling
- Battle critical-hit rendering
- all-four-Drifter structured move resolver compatibility coverage
- README update to v0.2.8.5

Branch head:
- 60a3340 Harden M8 battle rendering and compatibility

Validation:
- local pytest passing
- compileall passing
- latest branch CI green before final hardening, with new hardening CI expected on this PR