### PR TITLE
M9: Separate battle UI from combat engine

### DIFF
--- a/docs/m9-ui-engine-separation.md
+++ b/docs/m9-ui-engine-separation.md
@@ -1,0 +1,1687 @@
+# M9 UI / Engine Separation Plan
+
+## Document Status
+
+```text
+Planning contract: complete
+Implementation status: not started
+First code patch: UI-1A
+Branch: m9-ui-engine-separation
+Source-code baseline: 43198b7 Harden Brace resolver boundaries
+Baseline working tree: clean
+UI-0 repository artifact: m9-ui-engine-separation.md
+```
+
+UI-0 is complete as a planning contract. This Markdown file is the only approved UI-0 repository artifact. No production or test files were modified while producing it.
+
+---
+
+## Implementation Authority And Execution Policy
+
+This document is the controlling implementation contract for the complete M9 UI / Engine Separation milestone.
+
+X may implement the approved sequence without requesting approval between green patches. X must not reinterpret, widen, or silently revise the contract.
+
+Execution rules:
+
+- preserve the defined UI patch boundaries
+- one completed patch equals one commit
+- one completed patch equals one push to `m9-ui-engine-separation`
+- run the required focused and full verification before each commit
+- push each green commit before beginning the next patch
+- allow branch CI to run for each pushed commit
+- record the full commit SHA and CI result for every patch
+- continue automatically while local verification and pushed CI remain green
+- keep every commit independently reviewable
+- do not combine multiple UI patches into one commit
+- do not amend, squash, rebase, rewrite, or force-push completed patch commits
+- do not merge into `v0.2.9` or `master`
+- do not modify README or changelog
+
+Stop immediately and report before continuing when:
+
+- focused or full tests fail
+- compileall or `git diff --check` fails
+- pushed CI fails
+- a combat mechanic or accepted-action lifecycle contract must change
+- Resolver or `MoveResult` behavior must change
+- Heal, Items, or Escape require new gameplay
+- the approved ownership boundary cannot be preserved
+- an unexpected production dependency requires scope outside this document
+- a test exposes an unresolved contract ambiguity
+- unrelated files or behavior must change
+
+UI-0 itself is committed and pushed as the plan-document checkpoint before UI-1A begins.
+
+---
+
+## Objective
+
+Extract terminal input and presentation from `src/app/combat/battle.py` before M9B introduces additional dynamic character state.
+
+This milestone creates a renderer-neutral battle presentation boundary without rewriting:
+
+- combat mechanics
+- targeting
+- turn progression
+- accepted-action completion
+- temporary-state ownership
+- player or enemy data
+
+M9A demonstrated the need for this separation. Brace and its armed Heavy payoff are mechanically correct, but the existing terminal menu cannot clearly represent their dynamic state without adding presentation branches directly to `Battle`.
+
+---
+
+## Target Experience
+
+### Move Menu
+
+```text
+Choose a move:
+
+1. Crestgrave Reaping [Normal]
+   Sunder-Spire tears through the target, cleaving guard and armor.
+
+2. Cinderlung Vesper [Fire Magic | 3 Mana]
+   A black war-breath erupts forward, searing everything in its path.
+
+3. Brace [Utility | 5 Mana]
+   Brace against the next enemy action, reducing physical damage by 40%,
+   and empower your next Heavy attack by 30%.
+
+4. Ironwake Dismemberment [Heavy]
+   A crushing Sunder-Spire strike. Deals 30% more damage after Brace.
+
+0. Back
+```
+
+While the Brace payoff is armed:
+
+```text
+4. Ironwake Dismemberment [Heavy | Empowered +30%]
+```
+
+“Next enemy action” is intentional because accepted opposing actions consume Brace protection even when they miss or deal non-physical damage.
+
+### Persistent Battle HUD
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│ Joruun Veyr                                      Goblin      │
+│ HP   49/60                                      HP   40/60   │
+│ Mana 13/20                                                   │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│             [ CHARACTER / ENEMY VISUAL AREA ]                │
+│                                                              │
+├──────────────────────────────────────────────────────────────┤
+│ Joruun strikes the Goblin.                                   │
+│ The Goblin takes 12 damage.                                  │
+│ The Goblin prepares to attack.                               │
+├──────────────────────────────────────────────────────────────┤
+│   [ 1. Attack ]   [ 2. Defend ]   [ 3. Heal ]                │
+│   [ 4. Items  ]   [ 5. Escape ]                              │
+├──────────────────────────────────────────────────────────────┤
+│ SUPER  [██████████████████░░░░░░░░░░░░░░░░░░░░]             │
+└──────────────────────────────────────────────────────────────┘
+```
+
+When a Super move is affordable:
+
+```text
+│ SUPER  [████████████████████████████████████████] READY [S]  │
+```
+
+The intended hierarchy is:
+
+```text
+PLAYER / ENEMY STATUS
+CHARACTER VISUALS
+BATTLE LOG
+ATTACK · DEFEND · HEAL · ITEMS · ESCAPE
+PERSISTENT SUPER METER
+```
+
+---
+
+## Architectural Boundary
+
+```mermaid
+flowchart LR
+    B["Battle"] --> R["CombatResolver"]
+    B --> C["CombatState"]
+    B --> L["BattlePresentationSession"]
+    B --> P["BattlePresenter"]
+    L --> P
+    P --> V["Immutable BattleView"]
+    V --> U["TerminalBattleUI"]
+    U --> I["Typed BattleInput"]
+    I --> B
+```
+
+### Battle
+
+Owns:
+
+- encounter flow
+- turn ownership
+- interaction phase
+- semantic-input validation
+- target selection
+- resolver calls
+- accepted-action completion
+- victory and defeat checks
+- recording semantic presentation events
+
+Must not own:
+
+- terminal formatting
+- `print()` or `input()`
+- text wrapping
+- colors or borders
+- combat formulas
+- temporary mechanic state
+- retained UI rendering state
+
+### CombatResolver
+
+Continues to own:
+
+- move validation
+- targeting validation
+- resource spending
+- accuracy
+- dodge
+- damage
+- healing
+- critical resolution
+- Super gain
+- mechanical `MoveResult` creation
+
+No UI work belongs in the resolver.
+
+### CombatState
+
+Continues to own:
+
+- Defend state
+- Brace state
+- temporary encounter state
+- accepted-action completion
+- temporary-state expiry
+- turn count
+
+It may expose narrow, non-consuming observation methods for presentation.
+
+### BattlePresenter
+
+Owns:
+
+- conversion of read-only domain state into immutable views
+- action availability
+- move presentation
+- resource display values
+- dynamic presentation tags
+- Super-meter state
+- temporary-state labels
+
+It must remain pure and stateless.
+
+### BattlePresentationSession
+
+Owns:
+
+- encounter-local structured presentation history
+- bounded log retention
+- semantic input-rejection events
+- resolved-action events
+
+It does not own combat state and is not persisted in snapshots.
+
+### TerminalBattleUI
+
+Owns:
+
+- terminal rendering
+- width detection
+- wrapping
+- borders
+- Unicode and ASCII fallback
+- optional ANSI styling
+- screen refresh behavior
+- input aliases
+- translation of raw input into typed `BattleInput`
+
+It must retain no battle log or gameplay state.
+
+---
+
+## Immutable View Rule
+
+`BattleView` must contain only:
+
+- immutable dataclasses
+- tuples
+- strings
+- integers
+- booleans
+- presentation enums
+
+It must not expose:
+
+- `PlayerState`
+- `Character`
+- `EnemyState`
+- `CombatState`
+- `Move`
+- mutable resource containers
+- resolver objects
+- presentation-session objects
+
+This allows another renderer to consume the same view without understanding Python combat internals.
+
+---
+
+## Semantic Input Contract
+
+Battle must never receive terminal strings or menu indices.
+
+```python
+class ActionIntent(StrEnum):
+    ATTACK = "attack"
+    DEFEND = "defend"
+    HEAL = "heal"
+    ITEMS = "items"
+    ESCAPE = "escape"
+    SUPER = "super"
+
+
+@dataclass(frozen=True)
+class ChooseAction:
+    intent: ActionIntent
+
+
+@dataclass(frozen=True)
+class ChooseMove:
+    move_key: str
+
+
+@dataclass(frozen=True)
+class GoBack:
+    pass
+
+
+BattleInput = ChooseAction | ChooseMove | GoBack
+```
+
+Terminal translation examples:
+
+```text
+"1"       -> ChooseAction(ActionIntent.ATTACK)
+"defend"  -> ChooseAction(ActionIntent.DEFEND)
+"S"       -> ChooseAction(ActionIntent.SUPER)
+"4"       -> ChooseMove(offered_move_key)
+"0"       -> GoBack()
+```
+
+`move_key` may temporarily contain `Move.name` because that is the resolver’s current lookup contract.
+
+It remains opaque:
+
+- UI must not parse it.
+- Battle must not branch on its wording.
+- Presenter must not infer mechanics from it.
+- Stable move IDs remain a later schema migration.
+
+---
+
+## Interaction Phase Contract
+
+```python
+class InteractionPhase(StrEnum):
+    ACTIONS = "actions"
+    REGULAR_MOVES = "regular_moves"
+    HEALING_MOVES = "healing_moves"
+    SUPER_MOVES = "super_moves"
+```
+
+Every `BattleView` explicitly declares its interaction phase.
+
+| Phase | Valid ordinary input | Back |
+|---|---|---|
+| `ACTIONS` | Offered `ChooseAction` values | No |
+| `REGULAR_MOVES` | Offered regular `ChooseMove` values | Yes |
+| `HEALING_MOVES` | Offered non-Super healing moves | Yes |
+| `SUPER_MOVES` | Offered Super moves | Yes |
+
+`ChooseAction(SUPER)` may be offered from any phase when Super is ready. It transitions to `SUPER_MOVES` without advancing the turn.
+
+`InteractionPhase` is encounter-flow state owned by `Battle`. It is not `CombatState` and is not saved.
+
+---
+
+## Offered-Intent Enforcement
+
+The UI improves usability, but Battle enforces the interaction contract.
+
+```text
+Presenter builds BattleView
+-> UI renders that view
+-> UI returns BattleInput
+-> Battle validates input against that exact view
+-> Battle dispatches valid input
+```
+
+Rules:
+
+- `ChooseAction` must match an offered and enabled action.
+- `ChooseMove.move_key` must match an offered and enabled move.
+- `GoBack` is valid only during a move-selection phase.
+- `ChooseAction(SUPER)` must match an enabled Super meter.
+- Invalid semantic input must not reach the resolver.
+- Invalid semantic input must not mutate CombatState.
+- Invalid semantic input must not spend resources.
+- Invalid semantic input must not complete an action.
+- Invalid semantic input must not advance the turn.
+- Invalid semantic input leaves the same actor active.
+
+Resolver validation remains authoritative for:
+
+- targets
+- affordability
+- move support
+- actor/target validity
+- mechanical acceptance
+
+Battle validates whether an intent was offered. Resolver validates whether the resulting combat action is mechanically valid.
+
+---
+
+## Input Rejection
+
+Malformed terminal text should normally be handled inside `TerminalBattleUI` before returning a `BattleInput`.
+
+An unavailable or unoffered semantic input returned by a buggy or scripted adapter produces a structured presentation event with a renderer-neutral reason code:
+
+```python
+class InputRejectionReason(StrEnum):
+    ACTION_UNAVAILABLE = "action_unavailable"
+    MOVE_UNAVAILABLE = "move_unavailable"
+    BACK_UNAVAILABLE = "back_unavailable"
+    SUPER_UNAVAILABLE = "super_unavailable"
+
+
+BattleLogEntry(
+    event_type=BattleEventType.INPUT_REJECTED,
+    rejection_reason=InputRejectionReason.ACTION_UNAVAILABLE,
+)
+```
+
+The terminal renderer may present that code as:
+
+```text
+That action is not available.
+```
+
+Final user-facing prose must not be retained in the semantic event. The event must not create a `MoveResult`, because no combat action was attempted.
+
+---
+
+## Primary Presentation Models
+
+```text
+CombatantView
+ActionOptionView
+MoveOptionView
+SuperMeterView
+BattleLogEntry
+BattleVisualView
+BattleView
+```
+
+### CombatantView
+
+Contains:
+
+- display name
+- current and maximum HP
+- relevant current and maximum Mana
+- relevant current and maximum Super
+- Defend indicator
+- temporary presentation labels
+
+### ActionOptionView
+
+Contains:
+
+- action intent
+- displayed number
+- label
+- enabled state
+- disabled reason
+
+### MoveOptionView
+
+Contains:
+
+- selection key
+- displayed number
+- move name
+- presentation tags
+- rules summary
+- resource label
+- enabled state
+- disabled reason
+
+### SuperMeterView
+
+Contains:
+
+- current Super
+- maximum Super
+- normalized fill
+- ready state
+- activation key
+- whether activation is offered
+
+### BattleLogEntry
+
+Contains structured event data rather than terminal prose.
+
+Reasons and rejection details must use presentation enums or stable semantic codes. They must not store final player-facing sentences.
+
+### BattleVisualView
+
+Contains immutable visual references or fallback lines.
+
+It must not contain image objects or mutable asset handles.
+
+### BattleView
+
+Contains:
+
+- interaction phase
+- player view
+- enemy view
+- action options
+- move options for the current phase
+- Super meter
+- structured log entries
+- visual view
+
+---
+
+## Structured Battle Log
+
+`BattlePresentationSession` retains the bounded semantic history.
+
+Initial contract:
+
+```text
+Maximum retained entries: 20
+Standard HUD target: newest entries that fit at least 3 visible lines
+```
+
+The terminal renderer may show fewer or more entries depending on width and wrapping, but it never owns retention.
+
+Conceptual entry:
+
+```python
+BattleLogEntry(
+    event_type=BattleEventType.DAMAGE,
+    actor_name="Ser Branoc",
+    target_name="Goblin",
+    action_name="Ironwake Dismemberment",
+    accepted=True,
+    hit=True,
+    amount=21,
+    critical=False,
+    resource_spent=0,
+    reason=None,
+)
+```
+
+Initial event categories should cover:
+
+- encounter start
+- initiative
+- damage
+- critical damage
+- miss
+- healing
+- Defend
+- utility resolution
+- rejected action
+- unavailable semantic input
+- victory
+- defeat
+
+Terminal punctuation, wrapping, color, and icons remain renderer-owned.
+
+---
+
+## Pure Presenter Contract
+
+```python
+view = presenter.build(
+    player=player,
+    enemy=enemy,
+    combat_state=combat_state,
+    log_entries=session.entries,
+    interaction_phase=phase,
+)
+```
+
+The presenter may:
+
+- read actor resources
+- read authored moves
+- read immutable move-presentation metadata
+- call non-consuming CombatState queries
+- calculate display-only availability
+- produce fresh immutable view objects
+
+The presenter must not:
+
+- retain the presentation session
+- retain a previous view
+- consume Brace payoff
+- clear temporary state
+- mutate actors
+- mutate resources
+- advance turns
+- call the resolver
+- format terminal borders or prose
+- validate combat mechanics
+
+---
+
+## Move Presentation Contract
+
+`Move` may receive an optional immutable authored presentation object.
+
+Conceptual shape:
+
+```python
+class MoveRole(StrEnum):
+    NORMAL = "normal"
+    HEAVY = "heavy"
+    UTILITY = "utility"
+    HEALING = "healing"
+    SUPER = "super"
+
+
+@dataclass(frozen=True)
+class MovePresentation:
+    role: MoveRole
+    affinity_label: str | None
+    static_summary: str
+```
+
+The resolver must never inspect presentation metadata.
+
+Presentation metadata may provide:
+
+- Normal
+- Heavy
+- Utility
+- Healing
+- Super
+- non-mechanical affinity labels such as Fire
+- static summary text
+
+Resource labels are derived from existing move data:
+
+```text
+ResourceType.NONE + 0       -> no cost tag
+ResourceType.MANA + 3       -> 3 Mana
+ResourceType.SUPER + 100    -> 100 Super
+```
+
+Summary precedence is locked:
+
+```text
+When MovePresentation.static_summary is present:
+    use static_summary
+
+Otherwise:
+    fall back to Move.description
+```
+
+`Move.description` remains valid domain-authored fallback text. Presentation code must not concatenate both summaries or maintain duplicate independent copy.
+
+Static tag composition is locked:
+
+```text
+Normal physical damage move:
+[Normal]
+
+Normal magical move with affinity:
+[<Affinity> Magic]
+
+Heavy move:
+[Heavy]
+
+Utility move:
+[Utility]
+
+Healing move:
+[Healing]
+
+Super move:
+[Super]
+```
+
+Cinderlung Vesper therefore uses:
+
+```text
+role = Normal
+affinity_label = Fire
+damage_type = Magical
+
+rendered category:
+[Fire Magic]
+```
+
+It must not render as `[Normal | Fire]`.
+
+Tag ordering is locked:
+
+```text
+static role or category
+-> dynamic state
+-> resource cost
+```
+
+Examples:
+
+```text
+[Normal]
+[Fire Magic | 3 Mana]
+[Utility | 5 Mana]
+[Heavy | Empowered +30%]
+[Super | 100 Super]
+```
+
+Dynamic tags are presenter-owned:
+
+```text
+[Heavy | Empowered +30%]
+```
+
+Dynamic state must not be written into:
+
+- `Move.name`
+- `Move.description`
+- `Move.mechanic`
+- `MoveResult`
+- legacy `.moves`
+
+Branoc receives the first complete authored presentation metadata. Other moves may use deterministic generic presentation fallback until their M9 kit pass authors richer metadata.
+
+---
+
+## Brace Rules Source
+
+Brace’s rule values must have one public mechanics source.
+
+Conceptual shape:
+
+```python
+@dataclass(frozen=True)
+class BraceRules:
+    incoming_reduction_percent: int = 40
+    follow_up_damage_bonus_percent: int = 30
+    follow_up_mechanic: str = "heavy_attack"
+
+
+BRACE_RULES = BraceRules()
+```
+
+CombatState, resolver behavior, tests, and presentation must consume this source.
+
+The values `40` and `30` must not be independently duplicated in terminal formatting.
+
+This is a Brace-specific contract, not a generic status or modifier framework.
+
+---
+
+## Non-Consuming Brace Queries
+
+Add narrow read-only CombatState methods:
+
+```python
+brace_follow_up_damage_bonus_percent(actor, move_mechanic) -> int
+brace_incoming_protection_active(actor) -> bool
+```
+
+The follow-up query:
+
+- returns the active bonus for a matching mechanic
+- returns `0` when inactive or nonmatching
+- never consumes the payoff
+- never mutates state
+- uses object identity
+- exposes no `_brace_states`
+
+The incoming-protection query:
+
+- returns whether the protection window is active
+- does not apply damage reduction
+- does not consume protection
+- exposes no internal state
+
+The existing consuming follow-up method remains resolver-only.
+
+---
+
+## Action Hierarchy
+
+The permanent ordinary action row is:
+
+```text
+1. Attack
+2. Defend
+3. Heal
+4. Items
+5. Escape
+```
+
+### Attack
+
+Opens `REGULAR_MOVES`.
+
+Includes:
+
+- non-Super `MoveKind.DAMAGE`
+- non-Super `MoveKind.UTILITY`
+
+The submenu heading is:
+
+```text
+Choose a move:
+```
+
+Brace remains part of Branoc’s regular authored kit.
+
+### Defend
+
+Continues through:
+
+```python
+CombatResolver.resolve_defend(...)
+```
+
+Defend remains:
+
+- universal
+- separate from authored moves
+- separate from Brace
+- an accepted action when resolver-approved
+
+### Heal
+
+Opens `HEALING_MOVES`.
+
+It may route only:
+
+- already-authored
+- already-resolver-supported
+- non-Super `MoveKind.HEALING` moves
+
+This milestone must not:
+
+- add a universal heal
+- author new healing moves
+- change healing formulas
+- change healing targeting
+- add healing AI
+
+Heal remains disabled when the actor has no eligible healing moves.
+
+### Items
+
+Remains visible but disabled.
+
+No inventory-combat behavior is added.
+
+### Escape
+
+Remains visible but disabled.
+
+The existing pre-battle flee path is not converted into in-battle Escape.
+
+### Super
+
+Super is not assigned an ordinary action number.
+
+`S` opens `SUPER_MOVES` when at least one authored Super move is affordable.
+
+Super remains mechanically unchanged.
+
+---
+
+## Super Meter Contract
+
+Normal state:
+
+```text
+SUPER [██████████████░░░░░░░░░░] 40/100
+```
+
+Ready state:
+
+```text
+SUPER [████████████████████████] 100/100 READY [S]
+```
+
+Readiness is based on whether at least one authored Super move is affordable.
+
+The presenter derives readiness. The resolver still validates spending and acceptance.
+
+Super activation may be offered from any interaction phase because the meter is persistent.
+
+Selecting Super:
+
+- changes to `SUPER_MOVES`
+- does not spend Super
+- does not advance the turn
+- does not call the resolver until a specific Super move is selected
+
+---
+
+## Battle Lifecycle
+
+The accepted-action lifecycle must remain:
+
+```text
+UI returns typed intent
+-> Battle validates intent against presented view
+-> Battle navigates or selects actor/target
+-> Resolver returns MoveResult
+-> presentation session records semantic event
+-> Battle calls complete_accepted_action only when accepted
+-> Battle returns interaction phase to ACTIONS
+-> presenter builds the next BattleView
+-> UI renders the new view
+```
+
+Navigation input:
+
+- changes interaction phase only
+- never calls the resolver
+- never advances the turn
+
+Rejected resolver action:
+
+- records a structured rejection
+- does not complete the accepted action
+- does not advance the turn
+- does not clear Defend
+- does not expire Brace protection
+- keeps the actor active
+- remains in the relevant interaction phase
+
+Accepted action:
+
+- records the result
+- completes through CombatState
+- advances according to the existing contract
+- returns to `ACTIONS`
+
+---
+
+## TerminalBattleUI Contract
+
+Recommended protocol:
+
+```python
+class BattleUI(Protocol):
+    def render(self, view: BattleView) -> None:
+        ...
+
+    def read_input(self, view: BattleView) -> BattleInput:
+        ...
+```
+
+`TerminalBattleUI` receives injected input and output functions or streams for deterministic tests.
+
+It owns:
+
+- terminal width detection
+- interaction-phase headings
+- menu numbering
+- alias parsing
+- malformed raw-input feedback
+- wrapping
+- borders
+- optional ANSI
+- Unicode versus ASCII rendering
+- screen refresh behavior
+- final prose generation from structured events
+
+It does not own:
+
+- log retention
+- enabled-state calculation
+- move affordability calculation
+- targeting
+- action completion
+- combat state
+- current turn
+- current interaction phase
+- resource mutation
+
+---
+
+## Terminal Capability Rules
+
+Initial layout modes:
+
+```text
+80+ columns: full HUD
+60–79 columns: compact HUD
+below 60 columns: linear fallback
+```
+
+Required behavior:
+
+- interactive terminals may use ANSI refresh
+- redirected output uses append-only rendering
+- tests run with ANSI disabled
+- Unicode borders are optional
+- ASCII fallback must preserve all information
+- color must never be the only state indicator
+- unavailable actions require visible text or symbols
+- wrapping must not overlap adjacent regions
+- dynamic content must not resize unrelated regions incoherently
+
+Do not add a terminal graphics dependency during this milestone.
+
+---
+
+## Character Visual Area
+
+UI-4 establishes a `BattleVisualView` and a stable visual region.
+
+Initial implementation may use:
+
+- authored ASCII or Unicode lines
+- a neutral placeholder
+- name-based labels supplied through presentation data
+
+It must not:
+
+- add an image asset pipeline
+- load mutable image objects into `BattleView`
+- branch on character names inside the terminal renderer
+- change character or enemy domain objects solely for terminal art
+
+Graphical assets remain a later presentation-content patch.
+
+---
+
+## Target File Layout
+
+Expected new production areas:
+
+```text
+src/app/combat/brace.py
+src/app/combat/move_presentation.py
+
+src/app/presentation/__init__.py
+src/app/presentation/battle_models.py
+src/app/presentation/battle_session.py
+src/app/presentation/battle_presenter.py
+
+src/app/ui/__init__.py
+src/app/ui/battle_ui.py
+src/app/ui/terminal_battle_ui.py
+```
+
+Expected existing production files touched across the milestone:
+
+```text
+src/app/combat/battle.py
+src/app/combat/combat_state.py
+src/app/combat/move.py
+src/app/player/loadouts/branoc.py
+src/app/game/main_loop.py
+```
+
+Possible existing utility integration:
+
+```text
+src/app/game/console.py
+```
+
+Do not duplicate console-clearing behavior without first checking this module.
+
+---
+
+# Implementation Sequence
+
+## UI-0 — Interaction Contract
+
+### Status
+
+Complete as a planning contract.
+
+### Locks
+
+- typed `BattleInput`
+- explicit `InteractionPhase`
+- action grouping
+- disabled-action behavior
+- persistent Super access
+- Battle-side offered-intent validation
+- structured log ownership
+- presenter purity
+- terminal fallback rules
+- Heal interpretation
+- non-goals
+
+### Code
+
+No production or test code.
+
+The only UI-0 repository artifact is:
+
+```text
+m9-ui-engine-separation.md
+```
+
+Commit and push this plan-document checkpoint before UI-1A begins.
+
+### Gate
+
+UI-1A may begin only after the UI-0 plan commit is pushed and its branch CI is green.
+
+---
+
+## UI-1A — Brace Rules And Read-Only Queries
+
+### Purpose
+
+Centralize Brace’s mechanics-facing constants and expose non-consuming presentation queries.
+
+### Expected Changes
+
+```text
+src/app/combat/brace.py
+src/app/combat/combat_state.py
+tests/test_combat_state.py
+```
+
+Touch `resolver.py` only if required to consume the centralized rule source without behavior changes.
+
+### Required Tests
+
+- centralized values remain 40% and 30%
+- activation still uses the accepted values
+- follow-up query returns 30 for armed `heavy_attack`
+- follow-up query returns 0 when inactive
+- follow-up query returns 0 for nonmatching mechanics
+- query does not consume payoff
+- repeated query remains stable
+- incoming-protection query reports active/inactive correctly
+- queries support unhashable combatants
+- identity does not depend on names
+- existing consuming method still consumes exactly once
+- resolver damage remains unchanged
+
+### Non-Changes
+
+- no UI models
+- no Move changes
+- no Battle changes
+- no terminal changes
+- no mechanic behavior changes
+
+### Gate
+
+CombatState-focused tests and full suite pass.
+
+---
+
+## UI-1B — Inert Move Presentation Metadata
+
+### Purpose
+
+Provide authored display identity without changing resolver behavior.
+
+### Expected Changes
+
+```text
+src/app/combat/move_presentation.py
+src/app/combat/move.py
+src/app/player/loadouts/branoc.py
+tests/test_character_move_data.py
+tests/test_character_loadout_regression.py
+tests/test_move.py or equivalent
+```
+
+### Branoc Metadata
+
+```text
+Crestgrave Reaping      -> Normal
+Cinderlung Vesper       -> Fire affinity / Magic display
+Brace                    -> Utility
+Ironwake Dismemberment  -> Heavy
+Third Gate Obsequy      -> Super
+```
+
+### Required Tests
+
+- metadata is immutable
+- metadata validation rejects invalid role/summary values
+- Move accepts optional presentation metadata
+- `static_summary` is retained as inert authored metadata
+- missing `static_summary` permits the presenter to fall back to `Move.description`
+- all existing Move mechanics remain unchanged
+- resolver ignores presentation metadata
+- Branoc metadata matches authored intent
+- no resource, power, accuracy, target, or mechanic values change
+- legacy `.moves` remains untouched
+
+### Gate
+
+Move/loadout tests and full suite pass.
+
+---
+
+## UI-1C — Immutable Views, Events, And Session
+
+### Purpose
+
+Add renderer-neutral presentation structures without integrating Battle yet.
+
+### Expected Changes
+
+```text
+src/app/presentation/battle_models.py
+src/app/presentation/battle_session.py
+tests/test_battle_presentation_models.py
+tests/test_battle_presentation_session.py
+```
+
+### Required Tests
+
+- all models are frozen
+- collections are tuples
+- invalid negative resources are rejected
+- invalid maximum/current combinations are rejected as appropriate
+- log retention is bounded
+- oldest entries are discarded at capacity
+- event order is preserved
+- session exposes immutable entry snapshots
+- session owns no CombatState
+- no final terminal prose is stored
+- no domain objects appear in BattleView
+
+### Gate
+
+Pure model tests and full suite pass.
+
+---
+
+## UI-1D — Pure BattlePresenter
+
+### Purpose
+
+Build immutable `BattleView` values from read-only combat state.
+
+### Expected Changes
+
+```text
+src/app/presentation/battle_presenter.py
+tests/test_battle_presenter.py
+```
+
+### Required Presenter Behavior
+
+- builds player and enemy resource views
+- includes relevant Mana and Super
+- builds five ordinary action options
+- enables Attack appropriately
+- enables Defend
+- enables Heal only with eligible healing moves
+- disables Items
+- disables Escape
+- builds Super readiness
+- filters moves by interaction phase
+- creates resource labels
+- applies the locked summary-precedence rule
+- composes static, dynamic, and resource tags in the locked order
+- renders Cinderlung as `Fire Magic`, not `Normal | Fire`
+- creates generic fallback metadata
+- reads Brace payoff without consuming it
+- adds `Empowered +30%` only when armed
+- remains stateless across builds
+
+### Required Tests
+
+- repeated builds are equal when state is unchanged
+- builds do not mutate actors or CombatState
+- Brace query remains non-consuming
+- phase controls offered move categories
+- disabled reasons are present
+- no terminal formatting exists in views
+- no domain objects leak into views
+
+### Gate
+
+Presenter tests and full suite pass.
+
+---
+
+## UI-2A — Battle UI Protocol And Adapters
+
+### Purpose
+
+Define the presentation port before removing direct Battle I/O.
+
+### Expected Changes
+
+```text
+src/app/ui/battle_ui.py
+src/app/ui/terminal_battle_ui.py
+tests/test_battle_ui_contract.py
+tests/test_terminal_battle_ui.py
+```
+
+A scripted fake adapter should live in test support unless production use is justified.
+
+### Required Tests
+
+- raw numbers map to `ChooseAction`
+- aliases map correctly
+- `S` maps to Super
+- move numbers map to offered move keys
+- `0` maps to `GoBack` only where valid
+- malformed input reprompts locally
+- disabled choices are not returned as normal user input
+- adapter retains no log history
+- adapter does not mutate the supplied view
+- rendering works with injected streams
+
+### Compatibility Requirement
+
+A minimal behavior-equivalent terminal renderer must exist before Battle’s direct I/O is removed.
+
+No patch may leave the executable game without a functional battle UI.
+
+### Gate
+
+Contract and terminal-adapter tests pass.
+
+---
+
+## UI-2B — Extract Battle Input And Output
+
+### Purpose
+
+Remove terminal knowledge from Battle and enforce semantic-input validity.
+
+### Expected Changes
+
+```text
+src/app/combat/battle.py
+tests/test_battle_player_state.py
+```
+
+### Required Changes
+
+- inject the UI port
+- inject or create the presentation session per encounter
+- build views through the presenter
+- call `ui.render(view)`
+- receive `BattleInput`
+- validate against the exact offered view
+- route valid actions
+- record semantic events
+- remove direct move-result printing
+- remove direct HUD printing
+- remove direct menu input
+
+### Required Tests
+
+- fake UI drives Battle deterministically
+- Battle never receives terminal strings
+- invalid offered-intent attempts do not call resolver
+- disabled actions do not advance
+- GoBack changes phase only
+- Super can open from an offered phase
+- resolver rejection retains actor and phase
+- accepted actions complete exactly once
+- enemy actions still use resolver
+- Brace lifecycle remains unchanged
+- Battle contains no gameplay presentation branches
+
+### Migration Rule
+
+Existing tests must be redistributed, not silently deleted:
+
+- orchestration assertions remain Battle tests
+- text-format assertions move to terminal tests
+- direct private renderer tests are replaced by structured-event or adapter tests
+
+### Gate
+
+Focused Battle tests and full suite pass.
+
+---
+
+## UI-2C — Composition Root
+
+### Purpose
+
+Construct the production terminal adapter outside Battle.
+
+### Expected Changes
+
+```text
+src/app/game/main_loop.py
+src/app/game/console.py only if needed
+tests/test_main_flow_player_state.py
+tests/smoke_test_vertical_slice.py if required
+```
+
+### Required Changes
+
+- `main_loop.py` creates `TerminalBattleUI`
+- `main_loop.py` injects it into Battle
+- final Battle constructor has no hidden production-terminal dependency
+- story flow remains unchanged
+- existing pre-battle flee remains unchanged
+
+### Gate
+
+Main-flow tests, smoke tests, and full suite pass.
+
+---
+
+## UI-3 — Structured Move Menu
+
+### Purpose
+
+Deliver readable authored and dynamic move presentation.
+
+### Required Output
+
+```text
+1. Crestgrave Reaping [Normal]
+2. Cinderlung Vesper [Fire Magic | 3 Mana]
+3. Brace [Utility | 5 Mana]
+4. Ironwake Dismemberment [Heavy]
+```
+
+When armed:
+
+```text
+4. Ironwake Dismemberment [Heavy | Empowered +30%]
+```
+
+### Required Tests
+
+- no `[none 0]`
+- Mana labels are readable
+- Cinderlung renders exactly as `[Fire Magic | 3 Mana]`
+- summary precedence uses `static_summary` before `Move.description`
+- static, dynamic, and resource tags retain the locked order
+- descriptions wrap beneath move names
+- Back appears only in move phases
+- Brace rules use centralized values
+- Ironwake changes dynamically without state mutation
+- accepted Heavy hit removes the tag afterward
+- accepted Heavy miss removes the tag afterward
+- rejected Heavy preserves the tag
+- nonmatching move preserves the tag
+- Super remains separate
+
+### Manual Gate
+
+Perform a Branoc battle confirming:
+
+```text
+Brace -> enemy action -> empowered Ironwake
+```
+
+---
+
+## UI-4 — Persistent HUD And Super Meter
+
+### Purpose
+
+Implement the full battle hierarchy.
+
+### Required Sections
+
+```text
+status
+visuals
+battle log
+ordinary actions
+Super meter
+```
+
+### Required Tests
+
+- player HP/Mana/Super render correctly
+- enemy relevant resources render correctly
+- Defend state is visible
+- Brace-relevant state is visible where approved
+- five ordinary actions remain stable
+- disabled actions are visible
+- Super is never ordinary action 4
+- Super meter is always present
+- READY appears only when usable
+- `S` remains independently available
+- structured log preserves event order
+- layouts work at 120, 80, and 60 columns
+- ASCII mode preserves all meaning
+- ANSI-disabled output remains readable
+- no text overlaps or escapes panels
+
+### Manual Gate
+
+Verify interactive Windows 11 terminal behavior and redirected-output fallback.
+
+---
+
+## UI-5 — Regression Hardening
+
+### Purpose
+
+Close the separation milestone without adding features.
+
+### Required Coverage
+
+- all four Drifter move rosters display and resolve
+- Branoc dynamic Brace presentation works
+- regular moves remain resolver-driven
+- enemy moves remain resolver-driven
+- Defend remains universal/core
+- accepted-action completion remains CombatState-owned
+- rejected actions preserve actor and temporary state
+- Super gain and crit behavior remain unchanged
+- Items and Escape remain disabled
+- Heal remains category-only where no authored healing move exists
+- Battle has no direct `print()` or `input()`
+- TerminalBattleUI retains no encounter state
+- presenter remains pure
+- Goblin encounter completes
+
+### Manual Gate
+
+Complete the Goblin encounter with each Drifter when practical.
+
+This is a playability gate, not a balance gate.
+
+---
+
+## Standard Verification
+
+After every implementation patch and before its commit:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest <focused tests>
+.\.venv\Scripts\python.exe -m pytest
+.\.venv\Scripts\python.exe -m compileall src tests
+git diff --check
+git status --short
+```
+
+UI-3 through UI-5 also require relevant manual terminal checks.
+
+When all required local gates pass:
+
+```text
+commit that patch separately
+push that commit to m9-ui-engine-separation
+wait for or verify branch CI
+record the full SHA and CI result
+continue to the next patch only while CI remains green
+```
+
+A failed local gate must stop before commit. A failed pushed CI gate must stop before the next patch.
+
+---
+
+## Commit And Push Contract
+
+The milestone uses a strict reviewable history:
+
+```text
+UI-0  -> one plan-document commit -> push
+UI-1A -> one implementation commit -> push
+UI-1B -> one implementation commit -> push
+UI-1C -> one implementation commit -> push
+UI-1D -> one implementation commit -> push
+UI-2A -> one implementation commit -> push
+UI-2B -> one implementation commit -> push
+UI-2C -> one implementation commit -> push
+UI-3  -> one implementation commit -> push
+UI-4  -> one implementation commit -> push
+UI-5  -> one implementation commit -> push
+```
+
+Each patch commit must contain only that patch’s approved scope.
+
+Do not:
+
+- combine patches
+- amend a completed patch commit
+- squash commits
+- rebase or rewrite completed patch history
+- force-push
+- merge into `v0.2.9`
+- merge into `master`
+- modify README or changelog
+
+This history exists so M can review the complete milestone afterward one patch diff at a time.
+
+---
+
+## Reporting Contract
+
+Maintain a running implementation record while working. After each pushed patch, record:
+
+```text
+patch name
+state impact
+contracts added or changed
+files changed
+focused tests
+full pytest
+compileall
+git diff --check
+pre-commit working-tree status
+commit message
+full commit SHA
+push result
+CI run link
+CI status and conclusion
+manual test result when required
+what changed
+what did not change
+```
+
+Do not pause for approval between green patches.
+
+Stop and report immediately under the stop conditions in the Implementation Authority And Execution Policy section.
+
+After UI-5, provide one consolidated report containing the complete ordered commit list and every patch result so M can review each diff independently.
+
+---
+
+## Explicit Non-Goals
+
+Do not implement during this milestone:
+
+- universal healing
+- new healing moves
+- Items
+- in-battle Escape
+- party targeting
+- multi-enemy targeting
+- Android UI
+- browser UI
+- image asset pipeline
+- generic status/effect engine
+- Burn, Poison, Bleed, or Stun
+- XP
+- Growth Points
+- save/load changes
+- Battle mechanics rewrite
+- resolver mechanics rewrite
+- enemy or Goblin rebalance
+- move power or cost changes
+- legacy `.moves` removal
+- README or changelog updates
+
+---
+
+## Known Transitional Limits
+
+- `Move.name` remains the temporary resolver and presentation selection key.
+- Only Branoc initially receives complete authored presentation metadata.
+- Other Drifters may use generic fallback labels until their M9 identity passes.
+- Character visuals begin with immutable fallbacks, not an asset system.
+- Story screens still use the existing console path.
+- Party and Android interfaces remain future adapters.
+
+These limits must be documented rather than silently “solved” by expanding scope.
+
+---
+
+## Completion Gate
+
+The UI/engine separation is complete when:
+
+- `Battle` contains no direct `input()` or `print()`.
+- Battle accepts only typed semantic input.
+- Battle validates input against the exact offered view.
+- `BattlePresenter` is pure and stateless.
+- `BattleView` contains no mutable domain objects.
+- `BattlePresentationSession` owns bounded structured history.
+- `TerminalBattleUI` owns no retained encounter state.
+- Brace values have one mechanics source.
+- Brace and Ironwake dynamic presentation is non-consuming.
+- Super is persistently visible and independently activated.
+- unavailable actions cannot advance turns.
+- all four Drifter move sets remain compatible.
+- the Goblin vertical slice remains playable.
+- UI-0 through UI-5 each exist as a separate pushed commit.
+- every pushed patch CI gate is green.
+- no completed patch history was amended, squashed, rebased, or force-pushed.
+- full pytest passes.
+- compileall passes.
+- `git diff --check` passes.
+- the working tree is clean after the final pushed patch.
+
+---
+
+## Line To Protect Hardest
+
+> Presentation may observe combat state and return semantic intent. It may never decide, consume, or mutate combat mechanics.

--- a/src/app/combat/battle.py
+++ b/src/app/combat/battle.py
@@ -165,11 +165,7 @@ class Battle:
                     if player_won
                     else BattleEventType.DEFEAT
                 ),
-                actor_name=(
-                    self.player_state.display_name
-                    if player_won
-                    else self.player_state.display_name
-                ),
+                actor_name=self.player_state.display_name,
                 target_name=self.foe.display_name,
             )
         )
@@ -236,39 +232,6 @@ class Battle:
                     )
                     self.interaction_phase = InteractionPhase.ACTIONS
                     return True
-
-    def _player_attack_menu(self):
-        return self._player_move_menu(InteractionPhase.REGULAR_MOVES)
-
-    def _player_super_menu(self):
-        return self._player_move_menu(InteractionPhase.SUPER_MOVES)
-
-    def _player_move_menu(self, phase):
-        self.interaction_phase = phase
-        while True:
-            view = self._render_current_view()
-            battle_input = self.ui.read_input(view)
-            rejection_reason = self._input_rejection_reason(view, battle_input)
-            if rejection_reason is not None:
-                self._record_input_rejection(rejection_reason)
-                continue
-            if isinstance(battle_input, GoBack):
-                self.interaction_phase = InteractionPhase.ACTIONS
-                return False
-            if isinstance(battle_input, ChooseAction):
-                self.interaction_phase = InteractionPhase.SUPER_MOVES
-                continue
-
-            move = self._move_for_key(view, battle_input.move_key)
-            result = self._resolve_player_move(move)
-            if result.accepted:
-                self._complete_accepted_action(
-                    self.player_state,
-                    (self.foe,),
-                    result,
-                )
-                self.interaction_phase = InteractionPhase.ACTIONS
-                return True
 
     def _move_for_key(self, view, move_key):
         for option in view.move_options:

--- a/src/app/combat/battle.py
+++ b/src/app/combat/battle.py
@@ -3,15 +3,38 @@ import random
 from app.combat.combat_state import CombatState
 from app.combat.move import TargetType
 from app.combat.resolver import CombatResolver
+from app.presentation.battle_models import (
+    ActionIntent,
+    BattleEventType,
+    BattleLogEntry,
+    InputRejectionReason,
+    InteractionPhase,
+)
+from app.presentation.battle_presenter import BattlePresenter
+from app.presentation.battle_session import BattlePresentationSession
+from app.ui.battle_ui import ChooseAction, ChooseMove, GoBack
+from app.ui.terminal_battle_ui import TerminalBattleUI
 
 
 class Battle:
-    def __init__(self, player_state, foe, resolver=None):
+    def __init__(
+        self,
+        player_state,
+        foe,
+        resolver=None,
+        ui=None,
+        presenter=None,
+        presentation_session=None,
+    ):
         self.player_state = player_state
         self.player = player_state.character
         self.foe = foe
         self.combat_state = CombatState()
         self.resolver = resolver or CombatResolver()
+        self.ui = ui or TerminalBattleUI()
+        self.presenter = presenter or BattlePresenter()
+        self.presentation_session = presentation_session or BattlePresentationSession()
+        self.interaction_phase = InteractionPhase.ACTIONS
 
     def _player_moves(self):
         return self.player_state.combat_moves
@@ -37,17 +60,14 @@ class Battle:
         raise ValueError(f"Unsupported player move target: {move.target!r}")
 
     def _resolve_player_move(self, move):
+        target = self._player_target_for_move(move)
         result = self.resolver.resolve_move(
             self.player_state,
-            self._player_target_for_move(move),
+            target,
             move.name,
             combat_state=self.combat_state,
         )
-        self._render_move_result(
-            result,
-            actor=self.player_state,
-            target=self._player_target_for_move(move),
-        )
+        self._record_move_result(result, actor=self.player_state, target=target)
         return result
 
     def _enemy_target_for_move(self, move):
@@ -59,65 +79,75 @@ class Battle:
         raise ValueError(f"Unsupported enemy move target: {move.target!r}")
 
     def _resolve_enemy_move(self, move):
+        target = self._enemy_target_for_move(move)
         result = self.resolver.resolve_move(
             self.foe,
-            self._enemy_target_for_move(move),
+            target,
             move.name,
             combat_state=self.combat_state,
         )
-        self._render_move_result(
-            result,
-            actor=self.foe,
-            target=self._enemy_target_for_move(move),
-        )
+        self._record_move_result(result, actor=self.foe, target=target)
         return result
 
-    def _render_move_result(self, result, actor, target=None):
-        actor_name = actor.display_name
-        if not result.accepted:
-            print(f"{actor_name} used {result.move_name}, but it failed: {result.reason}.")
-            return
-        if result.move_name == "Defend":
-            print(f"{actor_name} used Defend.")
-            self._render_move_result_details(result)
-            return
-        if not result.hit:
-            print(f"{actor_name} used {result.move_name}, but missed.")
-            self._render_move_result_details(result)
-            return
-        if result.damage:
-            critical_text = " Critical hit!" if result.critical else ""
-            print(
-                f"{actor_name} used {result.move_name}."
-                f"{critical_text} It dealt {result.damage} damage."
+    def _record_move_result(self, result, actor, target=None, event_type=None):
+        self.presentation_session.record(
+            BattleLogEntry(
+                event_type=event_type or self._event_type_for_result(result),
+                actor_name=actor.display_name,
+                target_name=target.display_name if target is not None else None,
+                action_name=result.move_name,
+                accepted=result.accepted,
+                hit=result.hit,
+                amount=result.damage or result.healing,
+                critical=result.critical,
+                resource_spent=result.resource_spent,
+                statuses_applied=result.statuses_applied,
+                reason=result.reason,
             )
-            self._render_move_result_details(result)
-            return
-        if result.healing:
-            print(f"{actor_name} used {result.move_name}. It restored {result.healing} health.")
-            self._render_move_result_details(result)
-            return
-
-        print(f"{actor_name} used {result.move_name}. It resolved.")
-        self._render_move_result_details(result)
+        )
 
     @staticmethod
-    def _render_move_result_details(result):
-        if result.resource_spent:
-            print(f"Resource spent: {result.resource_spent}.")
-        if result.statuses_applied:
-            print(f"Statuses applied: {', '.join(result.statuses_applied)}.")
+    def _event_type_for_result(result):
+        if not result.accepted:
+            return BattleEventType.ACTION_REJECTED
+        if not result.hit:
+            return BattleEventType.MISS
+        if result.damage:
+            return BattleEventType.DAMAGE
+        if result.healing:
+            return BattleEventType.HEALING
+        return BattleEventType.UTILITY
+
+    def _build_view(self):
+        return self.presenter.build(
+            player=self.player_state,
+            enemy=self.foe,
+            combat_state=self.combat_state,
+            log_entries=self.presentation_session.entries,
+            interaction_phase=self.interaction_phase,
+        )
+
+    def _render_current_view(self):
+        view = self._build_view()
+        self.ui.render(view)
+        return view
 
     def run(self):
-        print(f"\nA {self.foe.display_name} blocks your path!")
+        self.presentation_session.record(
+            BattleLogEntry(
+                event_type=BattleEventType.ENCOUNTER_START,
+                target_name=self.foe.display_name,
+            )
+        )
 
         player_turn = random.randint(1, 2) == 1
-        if player_turn:
-            print("\nPlayer will go first.")
-        else:
-            print("\nThe enemy will go first.")
-
-        self.print_health()
+        first_actor = self.player_state if player_turn else self.foe
+        self.presentation_session.record(
+            BattleLogEntry(
+                event_type=BattleEventType.INITIATIVE,
+                actor_name=first_actor.display_name,
+            )
+        )
 
         while self.player_state.is_alive() and self.foe.is_alive():
             if player_turn:
@@ -126,126 +156,168 @@ class Battle:
                 action_accepted = self.enemy_action()
 
             if action_accepted:
-                self.print_health()
                 player_turn = not player_turn
 
-        return "player" if not self.foe.is_alive() else "enemy"
+        player_won = not self.foe.is_alive()
+        self.presentation_session.record(
+            BattleLogEntry(
+                event_type=(
+                    BattleEventType.VICTORY
+                    if player_won
+                    else BattleEventType.DEFEAT
+                ),
+                actor_name=(
+                    self.player_state.display_name
+                    if player_won
+                    else self.player_state.display_name
+                ),
+                target_name=self.foe.display_name,
+            )
+        )
+        self.interaction_phase = InteractionPhase.ACTIONS
+        self._render_current_view()
+        return "player" if player_won else "enemy"
 
     def player_action(self):
+        self.interaction_phase = InteractionPhase.ACTIONS
         while True:
-            print('''
-Choose an action:
-1. Attack
-2. Defend
-3. Items
-4. Super
-            ''')
-            choice = input("> ").strip().lower()
-            if choice in ("1", "attack"):
-                if self._player_attack_menu():
-                    return True
+            view = self._render_current_view()
+            battle_input = self.ui.read_input(view)
+            rejection_reason = self._input_rejection_reason(view, battle_input)
+            if rejection_reason is not None:
+                self._record_input_rejection(rejection_reason)
                 continue
-            if choice in ("2", "defend"):
-                result = self.resolver.resolve_defend(
-                    self.player_state,
-                    self.combat_state,
-                )
-                self._render_move_result(result, actor=self.player_state)
+
+            if isinstance(battle_input, ChooseAction):
+                if battle_input.intent == ActionIntent.ATTACK:
+                    self.interaction_phase = InteractionPhase.REGULAR_MOVES
+                    continue
+                if battle_input.intent == ActionIntent.HEAL:
+                    self.interaction_phase = InteractionPhase.HEALING_MOVES
+                    continue
+                if battle_input.intent == ActionIntent.SUPER:
+                    self.interaction_phase = InteractionPhase.SUPER_MOVES
+                    continue
+                if battle_input.intent == ActionIntent.DEFEND:
+                    result = self.resolver.resolve_defend(
+                        self.player_state,
+                        self.combat_state,
+                    )
+                    self._record_move_result(
+                        result,
+                        actor=self.player_state,
+                        event_type=(
+                            BattleEventType.DEFEND
+                            if result.accepted
+                            else BattleEventType.ACTION_REJECTED
+                        ),
+                    )
+                    if result.accepted:
+                        self._complete_accepted_action(
+                            self.player_state,
+                            (self.foe,),
+                            result,
+                        )
+                        self.interaction_phase = InteractionPhase.ACTIONS
+                        return True
+                    continue
+
+            if isinstance(battle_input, GoBack):
+                self.interaction_phase = InteractionPhase.ACTIONS
+                continue
+
+            if isinstance(battle_input, ChooseMove):
+                move = self._move_for_key(view, battle_input.move_key)
+                result = self._resolve_player_move(move)
                 if result.accepted:
                     self._complete_accepted_action(
                         self.player_state,
                         (self.foe,),
                         result,
                     )
+                    self.interaction_phase = InteractionPhase.ACTIONS
                     return True
-                continue
-            if choice in ("3", "items"):
-                print("Items are not available yet.")
-                continue
-            if choice in ("4", "super"):
-                if self._player_super_menu():
-                    return True
-                continue
-
-            print("That is not a valid move. Please try again.")
 
     def _player_attack_menu(self):
-        moves = [
-            move
-            for move in self._player_moves()
-            if move.resource_type.value != "super"
-        ]
-
-        while True:
-            print("\nChoose an attack:")
-            for index, move in enumerate(moves, start=1):
-                print(
-                    f"{index}. {move.name} "
-                    f"[{move.resource_type.value} {move.resource_cost}] - "
-                    f"{move.description}"
-                )
-            print("0. Back")
-
-            choice = input("> ").strip().lower()
-            if choice == "0":
-                return False
-
-            selected_move = self._selected_menu_move(moves, choice)
-            if selected_move is not None:
-                result = self._resolve_player_move(selected_move)
-                if result.accepted:
-                    self._complete_accepted_action(
-                        self.player_state,
-                        (self.foe,),
-                        result,
-                    )
-                    return True
-                continue
-
-            print("That is not a valid move. Please try again.")
+        return self._player_move_menu(InteractionPhase.REGULAR_MOVES)
 
     def _player_super_menu(self):
-        moves = [
-            move
-            for move in self._player_moves()
-            if move.resource_type.value == "super"
-        ]
+        return self._player_move_menu(InteractionPhase.SUPER_MOVES)
 
+    def _player_move_menu(self, phase):
+        self.interaction_phase = phase
         while True:
-            print("\nChoose a Super:")
-            for index, move in enumerate(moves, start=1):
-                print(
-                    f"{index}. {move.name} "
-                    f"[{move.resource_type.value} {move.resource_cost}] - "
-                    f"{move.description}"
-                )
-            print("0. Back")
-
-            choice = input("> ").strip().lower()
-            if choice == "0":
-                return
-
-            selected_move = self._selected_menu_move(moves, choice)
-            if selected_move is not None:
-                result = self._resolve_player_move(selected_move)
-                if result.accepted:
-                    self._complete_accepted_action(
-                        self.player_state,
-                        (self.foe,),
-                        result,
-                    )
-                    return True
+            view = self._render_current_view()
+            battle_input = self.ui.read_input(view)
+            rejection_reason = self._input_rejection_reason(view, battle_input)
+            if rejection_reason is not None:
+                self._record_input_rejection(rejection_reason)
+                continue
+            if isinstance(battle_input, GoBack):
+                self.interaction_phase = InteractionPhase.ACTIONS
+                return False
+            if isinstance(battle_input, ChooseAction):
+                self.interaction_phase = InteractionPhase.SUPER_MOVES
                 continue
 
-            print("That is not a valid move. Please try again.")
+            move = self._move_for_key(view, battle_input.move_key)
+            result = self._resolve_player_move(move)
+            if result.accepted:
+                self._complete_accepted_action(
+                    self.player_state,
+                    (self.foe,),
+                    result,
+                )
+                self.interaction_phase = InteractionPhase.ACTIONS
+                return True
 
-    @staticmethod
-    def _selected_menu_move(moves, choice):
-        for index, move in enumerate(moves, start=1):
-            if choice in (str(index), move.name.lower()):
-                return move
+    def _move_for_key(self, view, move_key):
+        for option in view.move_options:
+            if option.selection_key == move_key:
+                for move in self._player_moves():
+                    if move.name == option.selection_key:
+                        return move
+        raise ValueError("move key was not offered")
 
-        return None
+    def _input_rejection_reason(self, view, battle_input):
+        if isinstance(battle_input, ChooseAction):
+            if battle_input.intent == ActionIntent.SUPER:
+                if view.super_meter.activation_offered:
+                    return None
+                return InputRejectionReason.SUPER_UNAVAILABLE
+            if view.interaction_phase != InteractionPhase.ACTIONS:
+                return InputRejectionReason.ACTION_UNAVAILABLE
+            if any(
+                option.intent == battle_input.intent and option.enabled
+                for option in view.action_options
+            ):
+                return None
+            return InputRejectionReason.ACTION_UNAVAILABLE
+
+        if isinstance(battle_input, ChooseMove):
+            if view.interaction_phase == InteractionPhase.ACTIONS:
+                return InputRejectionReason.MOVE_UNAVAILABLE
+            if any(
+                option.selection_key == battle_input.move_key and option.enabled
+                for option in view.move_options
+            ):
+                return None
+            return InputRejectionReason.MOVE_UNAVAILABLE
+
+        if isinstance(battle_input, GoBack):
+            if view.interaction_phase != InteractionPhase.ACTIONS:
+                return None
+            return InputRejectionReason.BACK_UNAVAILABLE
+
+        return InputRejectionReason.ACTION_UNAVAILABLE
+
+    def _record_input_rejection(self, reason):
+        self.presentation_session.record(
+            BattleLogEntry(
+                event_type=BattleEventType.INPUT_REJECTED,
+                rejection_reason=reason,
+            )
+        )
 
     def enemy_action(self):
         move = random.choice(list(self._enemy_moves()))
@@ -258,43 +330,3 @@ Choose an action:
             )
 
         return result.accepted
-
-    def print_health(self):
-        print(
-            f"\n{self.player.display_name} HP: "
-            f"{self.player_state.health.current}/{self.player_state.health.maximum}"
-        )
-        print(
-            f"{self.player.display_name} Mana: "
-            f"{self.player_state.mana_resource.current}/{self.player_state.mana_resource.maximum}"
-        )
-        print(
-            f"{self.player.display_name} Super: "
-            f"{self.player_state.super_resource.current}/{self.player_state.super_resource.maximum}"
-        )
-        if self.combat_state.is_defending(self.player_state):
-            print(f"{self.player.display_name} Defending: yes")
-
-        print(
-            f"{self.foe.display_name} HP: "
-            f"{self.foe.health.current}/{self.foe.health.maximum}"
-        )
-        if self.foe.mana_resource.current or self.foe.mana_resource.maximum:
-            print(
-                f"{self.foe.display_name} Mana: "
-                f"{self.foe.mana_resource.current}/{self.foe.mana_resource.maximum}"
-            )
-        if self.foe.super_resource.current or self.foe.generates_super:
-            print(
-                f"{self.foe.display_name} Super: "
-                f"{self.foe.super_resource.current}/{self.foe.super_resource.maximum}"
-            )
-        if self.combat_state.is_defending(self.foe):
-            print(f"{self.foe.display_name} Defending: yes")
-
-        if self.combat_state.statuses:
-            print(f"Statuses: {self.combat_state.statuses}")
-        if self.combat_state.buffs:
-            print(f"Buffs: {self.combat_state.buffs}")
-        if self.combat_state.debuffs:
-            print(f"Debuffs: {self.combat_state.debuffs}")

--- a/src/app/combat/battle.py
+++ b/src/app/combat/battle.py
@@ -13,7 +13,6 @@ from app.presentation.battle_models import (
 from app.presentation.battle_presenter import BattlePresenter
 from app.presentation.battle_session import BattlePresentationSession
 from app.ui.battle_ui import ChooseAction, ChooseMove, GoBack
-from app.ui.terminal_battle_ui import TerminalBattleUI
 
 
 class Battle:
@@ -21,8 +20,8 @@ class Battle:
         self,
         player_state,
         foe,
+        ui,
         resolver=None,
-        ui=None,
         presenter=None,
         presentation_session=None,
     ):
@@ -31,7 +30,7 @@ class Battle:
         self.foe = foe
         self.combat_state = CombatState()
         self.resolver = resolver or CombatResolver()
-        self.ui = ui or TerminalBattleUI()
+        self.ui = ui
         self.presenter = presenter or BattlePresenter()
         self.presentation_session = presentation_session or BattlePresentationSession()
         self.interaction_phase = InteractionPhase.ACTIONS

--- a/src/app/combat/brace.py
+++ b/src/app/combat/brace.py
@@ -1,0 +1,13 @@
+"""Shared rules for Branoc's Brace combat mechanic."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BraceRules:
+    incoming_reduction_percent: int = 40
+    follow_up_damage_bonus_percent: int = 30
+    follow_up_mechanic: str = "heavy_attack"
+
+
+BRACE_RULES = BraceRules()

--- a/src/app/combat/combat_state.py
+++ b/src/app/combat/combat_state.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 
+from app.combat.brace import BRACE_RULES
 from app.combat.move import DamageType
 
 
@@ -45,8 +46,8 @@ class CombatState:
         self,
         owner,
         *,
-        incoming_reduction_percent=40,
-        heavy_payoff_damage_bonus_percent=30,
+        incoming_reduction_percent=BRACE_RULES.incoming_reduction_percent,
+        heavy_payoff_damage_bonus_percent=BRACE_RULES.follow_up_damage_bonus_percent,
     ):
         brace_state = _BraceState(
             owner=owner,
@@ -77,8 +78,22 @@ class CombatState:
 
         return brace_state.incoming_reduction_percent
 
+    def brace_incoming_protection_active(self, actor):
+        brace_state = self._find_brace_state(actor)
+        return bool(brace_state and brace_state.incoming_protection_active)
+
+    def brace_follow_up_damage_bonus_percent(self, actor, move_mechanic):
+        if move_mechanic != BRACE_RULES.follow_up_mechanic:
+            return 0
+
+        brace_state = self._find_brace_state(actor)
+        if brace_state is None or not brace_state.heavy_payoff_active:
+            return 0
+
+        return brace_state.heavy_payoff_damage_bonus_percent
+
     def consume_brace_follow_up_damage_bonus_percent(self, actor, move_mechanic):
-        if move_mechanic != "heavy_attack":
+        if move_mechanic != BRACE_RULES.follow_up_mechanic:
             return 0
 
         brace_state = self._find_brace_state(actor)

--- a/src/app/combat/move.py
+++ b/src/app/combat/move.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from enum import StrEnum
 
+from app.combat.move_presentation import MovePresentation
+
 
 class MoveKind(StrEnum):
     DAMAGE = "damage"
@@ -52,6 +54,7 @@ class Move:
     damage_type: DamageType
     mechanic: str | None
     description: str
+    presentation: MovePresentation | None = None
 
     def __post_init__(self):
         object.__setattr__(self, "name", _validate_nonempty_string("name", self.name))
@@ -80,6 +83,11 @@ class Move:
             self,
             "description",
             _validate_nonempty_string("description", self.description),
+        )
+        object.__setattr__(
+            self,
+            "presentation",
+            _validate_presentation(self.presentation),
         )
 
         if self.resource_type == ResourceType.NONE and self.resource_cost != 0:
@@ -115,6 +123,13 @@ def _validate_optional_string(name, value):
     if value is None:
         return None
     return _validate_nonempty_string(name, value)
+
+
+def _validate_presentation(value):
+    if value is None or isinstance(value, MovePresentation):
+        return value
+
+    raise TypeError("presentation must be MovePresentation or None")
 
 
 def _validate_nonnegative_integer(name, value):

--- a/src/app/combat/move_presentation.py
+++ b/src/app/combat/move_presentation.py
@@ -1,0 +1,50 @@
+"""Inert authored presentation metadata for combat moves."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class MoveRole(StrEnum):
+    NORMAL = "normal"
+    HEAVY = "heavy"
+    UTILITY = "utility"
+    HEALING = "healing"
+    SUPER = "super"
+
+
+@dataclass(frozen=True)
+class MovePresentation:
+    role: MoveRole
+    affinity_label: str | None = None
+    static_summary: str | None = None
+
+    def __post_init__(self):
+        object.__setattr__(self, "role", _validate_role(self.role))
+        object.__setattr__(
+            self,
+            "affinity_label",
+            _validate_optional_string("affinity_label", self.affinity_label),
+        )
+        object.__setattr__(
+            self,
+            "static_summary",
+            _validate_optional_string("static_summary", self.static_summary),
+        )
+
+
+def _validate_role(value):
+    try:
+        return MoveRole(value)
+    except ValueError as error:
+        raise ValueError(f"invalid role: {value!r}") from error
+
+
+def _validate_optional_string(name, value):
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    if not value:
+        raise ValueError(f"{name} must not be empty")
+
+    return value

--- a/src/app/game/main_loop.py
+++ b/src/app/game/main_loop.py
@@ -3,6 +3,7 @@ from app.enemies.factory import create_enemy_state
 from app.game import console
 from app.game.game_state import GameState
 from app.player.player_state import PlayerState
+from app.ui.terminal_battle_ui import TerminalBattleUI
 from app.world.event import Events
 from app.world.story import StoryElements
 
@@ -24,7 +25,11 @@ def main():
         story.escaped_ending(game_state.player_state.character)
         return
 
-    winner = Battle(game_state.player_state, create_enemy_state("goblin", tier=0)).run()
+    winner = Battle(
+        game_state.player_state,
+        create_enemy_state("goblin", tier=0),
+        ui=TerminalBattleUI(),
+    ).run()
     story.battle_ending(game_state.player_state.character, winner)
 
 

--- a/src/app/player/loadouts/branoc.py
+++ b/src/app/player/loadouts/branoc.py
@@ -1,4 +1,5 @@
 from app.combat.move import DamageType, Move, MoveKind, ResourceType, ScalingAttribute, TargetType
+from app.combat.move_presentation import MovePresentation, MoveRole
 from app.items.weapon import SunderSpire
 
 
@@ -37,7 +38,8 @@ def create_combat_moves():
             damage_type=DamageType.PHYSICAL,
             mechanic='basic_attack',
             # Deferred mechanic: guard and armor cleave
-            description='Sunder-Spire tears through the target, cleaving guard and armor.'),
+            description='Sunder-Spire tears through the target, cleaving guard and armor.',
+            presentation=MovePresentation(role=MoveRole.NORMAL)),
         Move(
             name='Cinderlung Vesper',
             kind=MoveKind.DAMAGE,
@@ -50,7 +52,11 @@ def create_combat_moves():
             damage_type=DamageType.MAGICAL,
             mechanic=None,
             # Deferred mechanic: line or multi-target war-breath
-            description='A black war-breath erupts forward, searing everything in its path.'),
+            description='A black war-breath erupts forward, searing everything in its path.',
+            presentation=MovePresentation(
+                role=MoveRole.NORMAL,
+                affinity_label='Fire',
+            )),
         Move(
             name='Brace',
             kind=MoveKind.UTILITY,
@@ -62,7 +68,8 @@ def create_combat_moves():
             target=TargetType.SELF,
             damage_type=DamageType.NONE,
             mechanic='brace',
-            description='Branoc plants Sunder-Spire and braces behind the Deep-Iron crest.'),
+            description='Branoc plants Sunder-Spire and braces behind the Deep-Iron crest.',
+            presentation=MovePresentation(role=MoveRole.UTILITY)),
         Move(
             name='Ironwake Dismemberment',
             kind=MoveKind.DAMAGE,
@@ -75,7 +82,11 @@ def create_combat_moves():
             damage_type=DamageType.PHYSICAL,
             mechanic='heavy_attack',
             # Deferred mechanic: battlefield-splitting impact
-            description='Branoc drives Sunder-Spire downward with battlefield-splitting force.'),
+            description='Branoc drives Sunder-Spire downward with battlefield-splitting force.',
+            presentation=MovePresentation(
+                role=MoveRole.HEAVY,
+                static_summary='A crushing Sunder-Spire strike.',
+            )),
         Move(
             name='Third Gate Obsequy',
             kind=MoveKind.DAMAGE,
@@ -88,7 +99,8 @@ def create_combat_moves():
             damage_type=DamageType.HYBRID,
             mechanic=None,
             # Deferred mechanic: Third Gate manifestation
-            description='A forbidden gate manifests behind Branoc, pouring ruin through Sunder-Spire.'),
+            description='A forbidden gate manifests behind Branoc, pouring ruin through Sunder-Spire.',
+            presentation=MovePresentation(role=MoveRole.SUPER)),
     ]
 
 

--- a/src/app/presentation/__init__.py
+++ b/src/app/presentation/__init__.py
@@ -1,0 +1,1 @@
+"""Renderer-neutral battle presentation contracts."""

--- a/src/app/presentation/battle_models.py
+++ b/src/app/presentation/battle_models.py
@@ -1,0 +1,371 @@
+"""Immutable renderer-neutral models for battle presentation."""
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class ActionIntent(StrEnum):
+    ATTACK = "attack"
+    DEFEND = "defend"
+    HEAL = "heal"
+    ITEMS = "items"
+    ESCAPE = "escape"
+    SUPER = "super"
+
+
+class InteractionPhase(StrEnum):
+    ACTIONS = "actions"
+    REGULAR_MOVES = "regular_moves"
+    HEALING_MOVES = "healing_moves"
+    SUPER_MOVES = "super_moves"
+
+
+class InputRejectionReason(StrEnum):
+    ACTION_UNAVAILABLE = "action_unavailable"
+    MOVE_UNAVAILABLE = "move_unavailable"
+    BACK_UNAVAILABLE = "back_unavailable"
+    SUPER_UNAVAILABLE = "super_unavailable"
+
+
+class BattleEventType(StrEnum):
+    ENCOUNTER_START = "encounter_start"
+    INITIATIVE = "initiative"
+    DAMAGE = "damage"
+    MISS = "miss"
+    HEALING = "healing"
+    DEFEND = "defend"
+    UTILITY = "utility"
+    ACTION_REJECTED = "action_rejected"
+    INPUT_REJECTED = "input_rejected"
+    VICTORY = "victory"
+    DEFEAT = "defeat"
+
+
+class ActionAvailabilityReason(StrEnum):
+    NO_REGULAR_MOVES = "no_regular_moves"
+    NO_HEALING_MOVES = "no_healing_moves"
+    NOT_IMPLEMENTED = "not_implemented"
+    SUPER_NOT_READY = "super_not_ready"
+
+
+class MoveAvailabilityReason(StrEnum):
+    INSUFFICIENT_RESOURCE = "insufficient_resource"
+
+
+@dataclass(frozen=True)
+class CombatantView:
+    display_name: str
+    hp_current: int
+    hp_maximum: int
+    mana_current: int | None = None
+    mana_maximum: int | None = None
+    super_current: int | None = None
+    super_maximum: int | None = None
+    defending: bool = False
+    temporary_labels: tuple[str, ...] = ()
+
+    def __post_init__(self):
+        object.__setattr__(self, "display_name", _validate_nonempty_string("display_name", self.display_name))
+        _validate_resource_pair("hp", self.hp_current, self.hp_maximum, optional=False)
+        _validate_resource_pair("mana", self.mana_current, self.mana_maximum, optional=True)
+        _validate_resource_pair("super", self.super_current, self.super_maximum, optional=True)
+        object.__setattr__(self, "defending", _validate_bool("defending", self.defending))
+        object.__setattr__(
+            self,
+            "temporary_labels",
+            _validate_string_tuple("temporary_labels", self.temporary_labels),
+        )
+
+
+@dataclass(frozen=True)
+class ActionOptionView:
+    intent: ActionIntent
+    number: int | None
+    label: str
+    enabled: bool
+    disabled_reason: ActionAvailabilityReason | None = None
+
+    def __post_init__(self):
+        object.__setattr__(self, "intent", _validate_enum("intent", self.intent, ActionIntent))
+        object.__setattr__(self, "number", _validate_optional_positive_integer("number", self.number))
+        object.__setattr__(self, "label", _validate_nonempty_string("label", self.label))
+        object.__setattr__(self, "enabled", _validate_bool("enabled", self.enabled))
+        object.__setattr__(
+            self,
+            "disabled_reason",
+            _validate_optional_enum(
+                "disabled_reason",
+                self.disabled_reason,
+                ActionAvailabilityReason,
+            ),
+        )
+        _validate_availability(self.enabled, self.disabled_reason)
+
+
+@dataclass(frozen=True)
+class MoveOptionView:
+    selection_key: str
+    number: int
+    name: str
+    tags: tuple[str, ...]
+    rules_summary: str
+    resource_label: str | None
+    enabled: bool
+    disabled_reason: MoveAvailabilityReason | None = None
+
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "selection_key",
+            _validate_nonempty_string("selection_key", self.selection_key),
+        )
+        object.__setattr__(self, "number", _validate_positive_integer("number", self.number))
+        object.__setattr__(self, "name", _validate_nonempty_string("name", self.name))
+        object.__setattr__(self, "tags", _validate_string_tuple("tags", self.tags))
+        object.__setattr__(
+            self,
+            "rules_summary",
+            _validate_nonempty_string("rules_summary", self.rules_summary),
+        )
+        object.__setattr__(
+            self,
+            "resource_label",
+            _validate_optional_string("resource_label", self.resource_label),
+        )
+        object.__setattr__(self, "enabled", _validate_bool("enabled", self.enabled))
+        object.__setattr__(
+            self,
+            "disabled_reason",
+            _validate_optional_enum(
+                "disabled_reason",
+                self.disabled_reason,
+                MoveAvailabilityReason,
+            ),
+        )
+        _validate_availability(self.enabled, self.disabled_reason)
+
+
+@dataclass(frozen=True)
+class SuperMeterView:
+    current: int
+    maximum: int
+    fill_bps: int
+    ready: bool
+    activation_key: str
+    activation_offered: bool
+
+    def __post_init__(self):
+        _validate_resource_pair("super", self.current, self.maximum, optional=False)
+        object.__setattr__(self, "fill_bps", _validate_basis_points("fill_bps", self.fill_bps))
+        object.__setattr__(self, "ready", _validate_bool("ready", self.ready))
+        object.__setattr__(
+            self,
+            "activation_key",
+            _validate_nonempty_string("activation_key", self.activation_key),
+        )
+        object.__setattr__(
+            self,
+            "activation_offered",
+            _validate_bool("activation_offered", self.activation_offered),
+        )
+        if self.activation_offered and not self.ready:
+            raise ValueError("Super activation cannot be offered when the meter is not ready")
+
+
+@dataclass(frozen=True)
+class BattleLogEntry:
+    event_type: BattleEventType
+    actor_name: str | None = None
+    target_name: str | None = None
+    action_name: str | None = None
+    accepted: bool | None = None
+    hit: bool | None = None
+    amount: int = 0
+    critical: bool = False
+    resource_spent: int = 0
+    statuses_applied: tuple[str, ...] = ()
+    reason: str | None = None
+    rejection_reason: InputRejectionReason | None = None
+
+    def __post_init__(self):
+        object.__setattr__(self, "event_type", _validate_enum("event_type", self.event_type, BattleEventType))
+        for name in ("actor_name", "target_name", "action_name", "reason"):
+            object.__setattr__(self, name, _validate_optional_string(name, getattr(self, name)))
+        object.__setattr__(self, "accepted", _validate_optional_bool("accepted", self.accepted))
+        object.__setattr__(self, "hit", _validate_optional_bool("hit", self.hit))
+        object.__setattr__(self, "amount", _validate_nonnegative_integer("amount", self.amount))
+        object.__setattr__(self, "critical", _validate_bool("critical", self.critical))
+        object.__setattr__(
+            self,
+            "resource_spent",
+            _validate_nonnegative_integer("resource_spent", self.resource_spent),
+        )
+        object.__setattr__(
+            self,
+            "statuses_applied",
+            _validate_string_tuple("statuses_applied", self.statuses_applied),
+        )
+        object.__setattr__(
+            self,
+            "rejection_reason",
+            _validate_optional_enum(
+                "rejection_reason",
+                self.rejection_reason,
+                InputRejectionReason,
+            ),
+        )
+        if self.event_type == BattleEventType.INPUT_REJECTED and self.rejection_reason is None:
+            raise ValueError("input_rejected events require rejection_reason")
+        if self.event_type != BattleEventType.INPUT_REJECTED and self.rejection_reason is not None:
+            raise ValueError("rejection_reason is only valid for input_rejected events")
+
+
+@dataclass(frozen=True)
+class BattleVisualView:
+    player_lines: tuple[str, ...] = ()
+    enemy_lines: tuple[str, ...] = ()
+
+    def __post_init__(self):
+        object.__setattr__(self, "player_lines", _validate_string_tuple("player_lines", self.player_lines))
+        object.__setattr__(self, "enemy_lines", _validate_string_tuple("enemy_lines", self.enemy_lines))
+
+
+@dataclass(frozen=True)
+class BattleView:
+    interaction_phase: InteractionPhase
+    player: CombatantView
+    enemy: CombatantView
+    super_meter: SuperMeterView
+    action_options: tuple[ActionOptionView, ...] = ()
+    move_options: tuple[MoveOptionView, ...] = ()
+    log_entries: tuple[BattleLogEntry, ...] = ()
+    visual: BattleVisualView = field(default_factory=BattleVisualView)
+
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "interaction_phase",
+            _validate_enum("interaction_phase", self.interaction_phase, InteractionPhase),
+        )
+        _validate_instance("player", self.player, CombatantView)
+        _validate_instance("enemy", self.enemy, CombatantView)
+        _validate_instance("super_meter", self.super_meter, SuperMeterView)
+        object.__setattr__(
+            self,
+            "action_options",
+            _validate_instance_tuple("action_options", self.action_options, ActionOptionView),
+        )
+        object.__setattr__(
+            self,
+            "move_options",
+            _validate_instance_tuple("move_options", self.move_options, MoveOptionView),
+        )
+        object.__setattr__(
+            self,
+            "log_entries",
+            _validate_instance_tuple("log_entries", self.log_entries, BattleLogEntry),
+        )
+        _validate_instance("visual", self.visual, BattleVisualView)
+
+
+def _validate_enum(name, value, enum_type):
+    try:
+        return enum_type(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"invalid {name}: {value!r}") from error
+
+
+def _validate_optional_enum(name, value, enum_type):
+    if value is None:
+        return None
+    return _validate_enum(name, value, enum_type)
+
+
+def _validate_bool(name, value):
+    if not isinstance(value, bool):
+        raise TypeError(f"{name} must be a boolean")
+    return value
+
+
+def _validate_optional_bool(name, value):
+    if value is None:
+        return None
+    return _validate_bool(name, value)
+
+
+def _validate_nonnegative_integer(name, value):
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer")
+    if value < 0:
+        raise ValueError(f"{name} must not be negative")
+    return value
+
+
+def _validate_positive_integer(name, value):
+    value = _validate_nonnegative_integer(name, value)
+    if value == 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _validate_optional_positive_integer(name, value):
+    if value is None:
+        return None
+    return _validate_positive_integer(name, value)
+
+
+def _validate_basis_points(name, value):
+    value = _validate_nonnegative_integer(name, value)
+    if value > 10_000:
+        raise ValueError(f"{name} must not exceed 10000")
+    return value
+
+
+def _validate_nonempty_string(name, value):
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    if not value.strip():
+        raise ValueError(f"{name} must not be empty")
+    return value
+
+
+def _validate_optional_string(name, value):
+    if value is None:
+        return None
+    return _validate_nonempty_string(name, value)
+
+
+def _validate_string_tuple(name, values):
+    if not isinstance(values, tuple):
+        raise TypeError(f"{name} must be a tuple")
+    return tuple(_validate_nonempty_string(name, value) for value in values)
+
+
+def _validate_resource_pair(name, current, maximum, *, optional):
+    if optional and current is None and maximum is None:
+        return
+    if current is None or maximum is None:
+        raise ValueError(f"{name} current and maximum must both be provided")
+    current = _validate_nonnegative_integer(f"{name}_current", current)
+    maximum = _validate_positive_integer(f"{name}_maximum", maximum)
+    if current > maximum:
+        raise ValueError(f"{name} current must not exceed maximum")
+
+
+def _validate_availability(enabled, disabled_reason):
+    if enabled and disabled_reason is not None:
+        raise ValueError("enabled options must not have a disabled reason")
+    if not enabled and disabled_reason is None:
+        raise ValueError("disabled options require a disabled reason")
+
+
+def _validate_instance(name, value, expected_type):
+    if not isinstance(value, expected_type):
+        raise TypeError(f"{name} must be {expected_type.__name__}")
+    return value
+
+
+def _validate_instance_tuple(name, values, expected_type):
+    if not isinstance(values, tuple):
+        raise TypeError(f"{name} must be a tuple")
+    return tuple(_validate_instance(name, value, expected_type) for value in values)

--- a/src/app/presentation/battle_models.py
+++ b/src/app/presentation/battle_models.py
@@ -44,6 +44,7 @@ class BattleEventType(StrEnum):
 class ActionAvailabilityReason(StrEnum):
     NO_REGULAR_MOVES = "no_regular_moves"
     NO_HEALING_MOVES = "no_healing_moves"
+    CANNOT_DEFEND = "cannot_defend"
     NOT_IMPLEMENTED = "not_implemented"
     SUPER_NOT_READY = "super_not_ready"
 

--- a/src/app/presentation/battle_presenter.py
+++ b/src/app/presentation/battle_presenter.py
@@ -1,5 +1,6 @@
 """Pure translation from combat state to immutable battle views."""
 
+from app.combat.brace import BRACE_RULES
 from app.combat.move import DamageType, MoveKind, ResourceType
 from app.combat.move_presentation import MoveRole
 from app.presentation.battle_models import (
@@ -248,6 +249,12 @@ class BattlePresenter:
 
     @staticmethod
     def _rules_summary(move):
+        if move.mechanic == "brace":
+            return (
+                "Brace against the next enemy action, reducing physical damage by "
+                f"{BRACE_RULES.incoming_reduction_percent}%, and empower your next "
+                f"Heavy attack by {BRACE_RULES.follow_up_damage_bonus_percent}%."
+            )
         if move.presentation is not None and move.presentation.static_summary is not None:
             return move.presentation.static_summary
         return move.description

--- a/src/app/presentation/battle_presenter.py
+++ b/src/app/presentation/battle_presenter.py
@@ -1,0 +1,253 @@
+"""Pure translation from combat state to immutable battle views."""
+
+from app.combat.move import DamageType, MoveKind, ResourceType
+from app.combat.move_presentation import MoveRole
+from app.presentation.battle_models import (
+    ActionAvailabilityReason,
+    ActionIntent,
+    ActionOptionView,
+    BattleView,
+    BattleVisualView,
+    CombatantView,
+    InteractionPhase,
+    MoveAvailabilityReason,
+    MoveOptionView,
+    SuperMeterView,
+)
+
+
+class BattlePresenter:
+    def build(
+        self,
+        *,
+        player,
+        enemy,
+        combat_state,
+        log_entries=(),
+        interaction_phase=InteractionPhase.ACTIONS,
+    ):
+        phase = InteractionPhase(interaction_phase)
+        return BattleView(
+            interaction_phase=phase,
+            player=self._combatant_view(player, combat_state, is_player=True),
+            enemy=self._combatant_view(enemy, combat_state, is_player=False),
+            super_meter=self._super_meter_view(player),
+            action_options=self._action_options(player),
+            move_options=self._move_options(player, combat_state, phase),
+            log_entries=tuple(log_entries),
+            visual=BattleVisualView(),
+        )
+
+    def _combatant_view(self, combatant, combat_state, *, is_player):
+        mana_current, mana_maximum = self._relevant_mana(combatant, is_player=is_player)
+        super_current, super_maximum = self._relevant_super(combatant, is_player=is_player)
+        labels = []
+        if combat_state.is_defending(combatant):
+            labels.append("Defending")
+        if combat_state.brace_incoming_protection_active(combatant):
+            labels.append("Brace")
+
+        return CombatantView(
+            display_name=combatant.display_name,
+            hp_current=combatant.health.current,
+            hp_maximum=combatant.health.maximum,
+            mana_current=mana_current,
+            mana_maximum=mana_maximum,
+            super_current=super_current,
+            super_maximum=super_maximum,
+            defending=combat_state.is_defending(combatant),
+            temporary_labels=tuple(labels),
+        )
+
+    @staticmethod
+    def _relevant_mana(combatant, *, is_player):
+        resource = combatant.mana_resource
+        if is_player or resource.current or resource.maximum:
+            return resource.current, resource.maximum
+        return None, None
+
+    @staticmethod
+    def _relevant_super(combatant, *, is_player):
+        resource = combatant.super_resource
+        if is_player or resource.current or combatant.generates_super:
+            return resource.current, resource.maximum
+        return None, None
+
+    def _action_options(self, player):
+        regular_moves = self._regular_moves(player)
+        healing_moves = self._healing_moves(player)
+        can_defend = bool(player.can_defend)
+        return (
+            self._action_option(
+                ActionIntent.ATTACK,
+                1,
+                "Attack",
+                enabled=bool(regular_moves),
+                disabled_reason=ActionAvailabilityReason.NO_REGULAR_MOVES,
+            ),
+            self._action_option(
+                ActionIntent.DEFEND,
+                2,
+                "Defend",
+                enabled=can_defend,
+                disabled_reason=ActionAvailabilityReason.CANNOT_DEFEND,
+            ),
+            self._action_option(
+                ActionIntent.HEAL,
+                3,
+                "Heal",
+                enabled=bool(healing_moves),
+                disabled_reason=ActionAvailabilityReason.NO_HEALING_MOVES,
+            ),
+            self._action_option(
+                ActionIntent.ITEMS,
+                4,
+                "Items",
+                enabled=False,
+                disabled_reason=ActionAvailabilityReason.NOT_IMPLEMENTED,
+            ),
+            self._action_option(
+                ActionIntent.ESCAPE,
+                5,
+                "Escape",
+                enabled=False,
+                disabled_reason=ActionAvailabilityReason.NOT_IMPLEMENTED,
+            ),
+        )
+
+    @staticmethod
+    def _action_option(intent, number, label, *, enabled, disabled_reason):
+        return ActionOptionView(
+            intent=intent,
+            number=number,
+            label=label,
+            enabled=enabled,
+            disabled_reason=None if enabled else disabled_reason,
+        )
+
+    def _super_meter_view(self, player):
+        resource = player.super_resource
+        super_moves = self._super_moves(player)
+        ready = any(self._can_afford(player, move) for move in super_moves)
+        fill_bps = resource.current * 10_000 // resource.maximum
+        return SuperMeterView(
+            current=resource.current,
+            maximum=resource.maximum,
+            fill_bps=fill_bps,
+            ready=ready,
+            activation_key="S",
+            activation_offered=ready,
+        )
+
+    def _move_options(self, player, combat_state, phase):
+        if phase == InteractionPhase.ACTIONS:
+            return ()
+        if phase == InteractionPhase.REGULAR_MOVES:
+            moves = self._regular_moves(player)
+        elif phase == InteractionPhase.HEALING_MOVES:
+            moves = self._healing_moves(player)
+        else:
+            moves = self._super_moves(player)
+
+        return tuple(
+            self._move_option(player, combat_state, move, number)
+            for number, move in enumerate(moves, start=1)
+        )
+
+    def _move_option(self, player, combat_state, move, number):
+        resource_label = self._resource_label(move)
+        tags = [self._static_category(move)]
+        follow_up_bonus = combat_state.brace_follow_up_damage_bonus_percent(
+            player,
+            move.mechanic,
+        )
+        if follow_up_bonus:
+            tags.append(f"Empowered +{follow_up_bonus}%")
+        if resource_label is not None:
+            tags.append(resource_label)
+
+        enabled = self._can_afford(player, move)
+        return MoveOptionView(
+            selection_key=move.name,
+            number=number,
+            name=move.name,
+            tags=tuple(tags),
+            rules_summary=self._rules_summary(move),
+            resource_label=resource_label,
+            enabled=enabled,
+            disabled_reason=(
+                None
+                if enabled
+                else MoveAvailabilityReason.INSUFFICIENT_RESOURCE
+            ),
+        )
+
+    @staticmethod
+    def _regular_moves(player):
+        return tuple(
+            move
+            for move in player.combat_moves
+            if move.resource_type != ResourceType.SUPER
+            and move.kind in (MoveKind.DAMAGE, MoveKind.UTILITY)
+        )
+
+    @staticmethod
+    def _healing_moves(player):
+        return tuple(
+            move
+            for move in player.combat_moves
+            if move.resource_type != ResourceType.SUPER
+            and move.kind == MoveKind.HEALING
+        )
+
+    @staticmethod
+    def _super_moves(player):
+        return tuple(
+            move
+            for move in player.combat_moves
+            if move.resource_type == ResourceType.SUPER
+        )
+
+    @staticmethod
+    def _can_afford(player, move):
+        if move.resource_type == ResourceType.NONE:
+            return True
+        if move.resource_type == ResourceType.MANA:
+            return player.mana_resource.can_afford(move.resource_cost)
+        if move.resource_type == ResourceType.SUPER:
+            return player.super_resource.can_afford(move.resource_cost)
+        return False
+
+    @staticmethod
+    def _resource_label(move):
+        if move.resource_type == ResourceType.MANA:
+            return f"{move.resource_cost} Mana"
+        if move.resource_type == ResourceType.SUPER:
+            return f"{move.resource_cost} Super"
+        return None
+
+    @staticmethod
+    def _static_category(move):
+        presentation = move.presentation
+        role = presentation.role if presentation is not None else None
+        if move.resource_type == ResourceType.SUPER or role == MoveRole.SUPER:
+            return "Super"
+        if move.kind == MoveKind.HEALING or role == MoveRole.HEALING:
+            return "Healing"
+        if move.kind == MoveKind.UTILITY or role == MoveRole.UTILITY:
+            return "Utility"
+        if role == MoveRole.HEAVY:
+            return "Heavy"
+        if (
+            role == MoveRole.NORMAL
+            and presentation.affinity_label is not None
+            and move.damage_type == DamageType.MAGICAL
+        ):
+            return f"{presentation.affinity_label} Magic"
+        return "Normal"
+
+    @staticmethod
+    def _rules_summary(move):
+        if move.presentation is not None and move.presentation.static_summary is not None:
+            return move.presentation.static_summary
+        return move.description

--- a/src/app/presentation/battle_session.py
+++ b/src/app/presentation/battle_session.py
@@ -1,0 +1,34 @@
+"""Encounter-local ownership of bounded semantic battle history."""
+
+from app.presentation.battle_models import BattleLogEntry
+
+
+DEFAULT_MAX_LOG_ENTRIES = 20
+
+
+class BattlePresentationSession:
+    def __init__(self, max_entries=DEFAULT_MAX_LOG_ENTRIES):
+        if isinstance(max_entries, bool) or not isinstance(max_entries, int):
+            raise TypeError("max_entries must be an integer")
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+
+        self._max_entries = max_entries
+        self._entries = []
+
+    @property
+    def max_entries(self):
+        return self._max_entries
+
+    @property
+    def entries(self):
+        return tuple(self._entries)
+
+    def record(self, entry):
+        if not isinstance(entry, BattleLogEntry):
+            raise TypeError("entry must be a BattleLogEntry")
+
+        self._entries.append(entry)
+        overflow = len(self._entries) - self._max_entries
+        if overflow > 0:
+            del self._entries[:overflow]

--- a/src/app/ui/__init__.py
+++ b/src/app/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Battle user-interface adapters."""

--- a/src/app/ui/battle_ui.py
+++ b/src/app/ui/battle_ui.py
@@ -1,0 +1,46 @@
+"""Semantic battle input values and the battle UI port."""
+
+from dataclasses import dataclass
+from typing import Protocol, TypeAlias, runtime_checkable
+
+from app.presentation.battle_models import ActionIntent, BattleView
+
+
+@dataclass(frozen=True)
+class ChooseAction:
+    intent: ActionIntent
+
+    def __post_init__(self):
+        try:
+            intent = ActionIntent(self.intent)
+        except (TypeError, ValueError) as error:
+            raise ValueError(f"invalid action intent: {self.intent!r}") from error
+        object.__setattr__(self, "intent", intent)
+
+
+@dataclass(frozen=True)
+class ChooseMove:
+    move_key: str
+
+    def __post_init__(self):
+        if not isinstance(self.move_key, str):
+            raise TypeError("move_key must be a string")
+        if not self.move_key.strip():
+            raise ValueError("move_key must not be empty")
+
+
+@dataclass(frozen=True)
+class GoBack:
+    pass
+
+
+BattleInput: TypeAlias = ChooseAction | ChooseMove | GoBack
+
+
+@runtime_checkable
+class BattleUI(Protocol):
+    def render(self, view: BattleView) -> None:
+        ...
+
+    def read_input(self, view: BattleView) -> BattleInput:
+        ...

--- a/src/app/ui/terminal_battle_ui.py
+++ b/src/app/ui/terminal_battle_ui.py
@@ -1,0 +1,159 @@
+"""Stateless terminal rendering and semantic input translation."""
+
+import builtins
+
+from app.presentation.battle_models import (
+    ActionIntent,
+    BattleEventType,
+    BattleView,
+    InputRejectionReason,
+    InteractionPhase,
+)
+from app.ui.battle_ui import ChooseAction, ChooseMove, GoBack
+
+
+class TerminalBattleUI:
+    def __init__(self, *, input_func=None, output_func=None):
+        self._input = input_func or builtins.input
+        self._output = output_func or builtins.print
+
+    def render(self, view):
+        if not isinstance(view, BattleView):
+            raise TypeError("view must be a BattleView")
+
+        self._render_combatant(view.player)
+        self._render_combatant(view.enemy)
+        for entry in view.log_entries:
+            for line in self._log_lines(entry):
+                self._output(line)
+
+        if view.interaction_phase == InteractionPhase.ACTIONS:
+            self._output("Choose an action:")
+            for option in view.action_options:
+                suffix = "" if option.enabled else " [Unavailable]"
+                self._output(f"{option.number}. {option.label}{suffix}")
+        else:
+            self._output(self._phase_heading(view.interaction_phase))
+            for move in view.move_options:
+                tags = " | ".join(move.tags)
+                suffix = "" if move.enabled else " [Unavailable]"
+                self._output(f"{move.number}. {move.name} [{tags}]{suffix}")
+            self._output("0. Back")
+
+        meter = view.super_meter
+        ready = " READY [S]" if meter.activation_offered else ""
+        self._output(f"Super: {meter.current}/{meter.maximum}{ready}")
+
+    def read_input(self, view):
+        if not isinstance(view, BattleView):
+            raise TypeError("view must be a BattleView")
+
+        while True:
+            raw_value = self._input("> ")
+            if not isinstance(raw_value, str):
+                self._output("That is not a valid move. Please try again.")
+                continue
+
+            choice = raw_value.strip().lower()
+            selected = self._translate_choice(view, choice)
+            if selected is not None:
+                return selected
+
+            self._output("That is not a valid move. Please try again.")
+
+    def _translate_choice(self, view, choice):
+        if choice in ("s", "super"):
+            if view.super_meter.activation_offered:
+                return ChooseAction(ActionIntent.SUPER)
+            self._output("Super is not available.")
+            return None
+
+        if view.interaction_phase == InteractionPhase.ACTIONS:
+            return self._translate_action(view, choice)
+
+        if choice in ("0", "back"):
+            return GoBack()
+        return self._translate_move(view, choice)
+
+    def _translate_action(self, view, choice):
+        for option in view.action_options:
+            if choice not in (str(option.number), option.label.lower(), option.intent.value):
+                continue
+            if option.enabled:
+                return ChooseAction(option.intent)
+            self._output(f"{option.label} is not available.")
+            return None
+        return None
+
+    def _translate_move(self, view, choice):
+        for move in view.move_options:
+            if choice not in (str(move.number), move.name.lower()):
+                continue
+            if move.enabled:
+                return ChooseMove(move.selection_key)
+            self._output(f"{move.name} is not available.")
+            return None
+        return None
+
+    def _render_combatant(self, combatant):
+        self._output(
+            f"{combatant.display_name} HP: "
+            f"{combatant.hp_current}/{combatant.hp_maximum}"
+        )
+        if combatant.mana_current is not None:
+            self._output(
+                f"{combatant.display_name} Mana: "
+                f"{combatant.mana_current}/{combatant.mana_maximum}"
+            )
+        if combatant.super_current is not None:
+            self._output(
+                f"{combatant.display_name} Super: "
+                f"{combatant.super_current}/{combatant.super_maximum}"
+            )
+        for label in combatant.temporary_labels:
+            self._output(f"{combatant.display_name} {label}: yes")
+
+    @staticmethod
+    def _phase_heading(phase):
+        if phase == InteractionPhase.SUPER_MOVES:
+            return "Choose a Super:"
+        return "Choose a move:"
+
+    def _log_lines(self, entry):
+        actor = entry.actor_name or "Combatant"
+        target = entry.target_name or "target"
+        action = entry.action_name or "action"
+        if entry.event_type == BattleEventType.ENCOUNTER_START:
+            return (f"A {target} blocks your path!",)
+        if entry.event_type == BattleEventType.INITIATIVE:
+            return (f"{actor} will go first.",)
+        if entry.event_type == BattleEventType.DAMAGE:
+            critical = " Critical hit!" if entry.critical else ""
+            return (f"{actor} used {action}.{critical} It dealt {entry.amount} damage.",)
+        if entry.event_type == BattleEventType.MISS:
+            return (f"{actor} used {action}, but missed.",)
+        if entry.event_type == BattleEventType.HEALING:
+            return (f"{actor} used {action}. It restored {entry.amount} health.",)
+        if entry.event_type == BattleEventType.DEFEND:
+            return (f"{actor} used Defend.",)
+        if entry.event_type == BattleEventType.UTILITY:
+            return (f"{actor} used {action}. It resolved.",)
+        if entry.event_type == BattleEventType.ACTION_REJECTED:
+            return (f"{actor} used {action}, but it failed: {entry.reason}.",)
+        if entry.event_type == BattleEventType.INPUT_REJECTED:
+            return (self._input_rejection_text(entry.rejection_reason),)
+        if entry.event_type == BattleEventType.VICTORY:
+            return (f"{actor} is victorious over {target}.",)
+        if entry.event_type == BattleEventType.DEFEAT:
+            return (f"{actor} was defeated by {target}.",)
+        raise ValueError(f"unsupported battle event type: {entry.event_type!r}")
+
+    @staticmethod
+    def _input_rejection_text(reason):
+        if reason == InputRejectionReason.SUPER_UNAVAILABLE:
+            return "Super is not available."
+        if reason == InputRejectionReason.MOVE_UNAVAILABLE:
+            return "That move is not available."
+        if reason == InputRejectionReason.BACK_UNAVAILABLE:
+            return "Back is not available."
+        return "That action is not available."

--- a/src/app/ui/terminal_battle_ui.py
+++ b/src/app/ui/terminal_battle_ui.py
@@ -1,6 +1,8 @@
 """Stateless terminal rendering and semantic input translation."""
 
 import builtins
+import shutil
+import textwrap
 
 from app.presentation.battle_models import (
     ActionIntent,
@@ -13,9 +15,12 @@ from app.ui.battle_ui import ChooseAction, ChooseMove, GoBack
 
 
 class TerminalBattleUI:
-    def __init__(self, *, input_func=None, output_func=None):
+    def __init__(self, *, input_func=None, output_func=None, width_provider=None):
         self._input = input_func or (lambda prompt: builtins.input(prompt))
         self._output = output_func or (lambda message: builtins.print(message))
+        self._width_provider = width_provider or (
+            lambda: shutil.get_terminal_size((80, 24)).columns
+        )
 
     def render(self, view):
         if not isinstance(view, BattleView):
@@ -38,7 +43,13 @@ class TerminalBattleUI:
                 tags = " | ".join(move.tags)
                 suffix = "" if move.enabled else " [Unavailable]"
                 self._output(f"{move.number}. {move.name} [{tags}]{suffix}")
-                self._output(f"   {move.rules_summary}")
+                for line in textwrap.wrap(
+                    move.rules_summary,
+                    width=max(20, self._width_provider() - 3),
+                    break_long_words=False,
+                    break_on_hyphens=False,
+                ):
+                    self._output(f"   {line}")
             self._output("0. Back")
 
         meter = view.super_meter

--- a/src/app/ui/terminal_battle_ui.py
+++ b/src/app/ui/terminal_battle_ui.py
@@ -14,8 +14,8 @@ from app.ui.battle_ui import ChooseAction, ChooseMove, GoBack
 
 class TerminalBattleUI:
     def __init__(self, *, input_func=None, output_func=None):
-        self._input = input_func or builtins.input
-        self._output = output_func or builtins.print
+        self._input = input_func or (lambda prompt: builtins.input(prompt))
+        self._output = output_func or (lambda message: builtins.print(message))
 
     def render(self, view):
         if not isinstance(view, BattleView):
@@ -38,6 +38,7 @@ class TerminalBattleUI:
                 tags = " | ".join(move.tags)
                 suffix = "" if move.enabled else " [Unavailable]"
                 self._output(f"{move.number}. {move.name} [{tags}]{suffix}")
+                self._output(f"   {move.rules_summary}")
             self._output("0. Back")
 
         meter = view.super_meter
@@ -123,30 +124,38 @@ class TerminalBattleUI:
         actor = entry.actor_name or "Combatant"
         target = entry.target_name or "target"
         action = entry.action_name or "action"
+        lines = []
         if entry.event_type == BattleEventType.ENCOUNTER_START:
-            return (f"A {target} blocks your path!",)
-        if entry.event_type == BattleEventType.INITIATIVE:
-            return (f"{actor} will go first.",)
-        if entry.event_type == BattleEventType.DAMAGE:
+            lines.append(f"A {target} blocks your path!")
+        elif entry.event_type == BattleEventType.INITIATIVE:
+            lines.append(f"{actor} will go first.")
+        elif entry.event_type == BattleEventType.DAMAGE:
             critical = " Critical hit!" if entry.critical else ""
-            return (f"{actor} used {action}.{critical} It dealt {entry.amount} damage.",)
-        if entry.event_type == BattleEventType.MISS:
-            return (f"{actor} used {action}, but missed.",)
-        if entry.event_type == BattleEventType.HEALING:
-            return (f"{actor} used {action}. It restored {entry.amount} health.",)
-        if entry.event_type == BattleEventType.DEFEND:
-            return (f"{actor} used Defend.",)
-        if entry.event_type == BattleEventType.UTILITY:
-            return (f"{actor} used {action}. It resolved.",)
-        if entry.event_type == BattleEventType.ACTION_REJECTED:
-            return (f"{actor} used {action}, but it failed: {entry.reason}.",)
-        if entry.event_type == BattleEventType.INPUT_REJECTED:
-            return (self._input_rejection_text(entry.rejection_reason),)
-        if entry.event_type == BattleEventType.VICTORY:
-            return (f"{actor} is victorious over {target}.",)
-        if entry.event_type == BattleEventType.DEFEAT:
-            return (f"{actor} was defeated by {target}.",)
-        raise ValueError(f"unsupported battle event type: {entry.event_type!r}")
+            lines.append(f"{actor} used {action}.{critical} It dealt {entry.amount} damage.")
+        elif entry.event_type == BattleEventType.MISS:
+            lines.append(f"{actor} used {action}, but missed.")
+        elif entry.event_type == BattleEventType.HEALING:
+            lines.append(f"{actor} used {action}. It restored {entry.amount} health.")
+        elif entry.event_type == BattleEventType.DEFEND:
+            lines.append(f"{actor} used Defend.")
+        elif entry.event_type == BattleEventType.UTILITY:
+            lines.append(f"{actor} used {action}. It resolved.")
+        elif entry.event_type == BattleEventType.ACTION_REJECTED:
+            lines.append(f"{actor} used {action}, but it failed: {entry.reason}.")
+        elif entry.event_type == BattleEventType.INPUT_REJECTED:
+            lines.append(self._input_rejection_text(entry.rejection_reason))
+        elif entry.event_type == BattleEventType.VICTORY:
+            lines.append(f"{actor} is victorious over {target}.")
+        elif entry.event_type == BattleEventType.DEFEAT:
+            lines.append(f"{actor} was defeated by {target}.")
+        else:
+            raise ValueError(f"unsupported battle event type: {entry.event_type!r}")
+
+        if entry.resource_spent:
+            lines.append(f"Resource spent: {entry.resource_spent}.")
+        if entry.statuses_applied:
+            lines.append(f"Statuses applied: {', '.join(entry.statuses_applied)}.")
+        return tuple(lines)
 
     @staticmethod
     def _input_rejection_text(reason):

--- a/src/app/ui/terminal_battle_ui.py
+++ b/src/app/ui/terminal_battle_ui.py
@@ -2,6 +2,7 @@
 
 import builtins
 import shutil
+import sys
 import textwrap
 
 from app.presentation.battle_models import (
@@ -15,46 +16,43 @@ from app.ui.battle_ui import ChooseAction, ChooseMove, GoBack
 
 
 class TerminalBattleUI:
-    def __init__(self, *, input_func=None, output_func=None, width_provider=None):
+    def __init__(
+        self,
+        *,
+        input_func=None,
+        output_func=None,
+        width_provider=None,
+        unicode_enabled=True,
+        ansi_enabled=None,
+        interactive=None,
+    ):
         self._input = input_func or (lambda prompt: builtins.input(prompt))
         self._output = output_func or (lambda message: builtins.print(message))
         self._width_provider = width_provider or (
             lambda: shutil.get_terminal_size((80, 24)).columns
         )
+        self._unicode_enabled = bool(unicode_enabled)
+        if interactive is None:
+            interactive = sys.stdin.isatty() and sys.stdout.isatty()
+        if ansi_enabled is None:
+            ansi_enabled = interactive
+        self._ansi_enabled = bool(ansi_enabled)
+        self._interactive = bool(interactive)
 
     def render(self, view):
         if not isinstance(view, BattleView):
             raise TypeError("view must be a BattleView")
 
-        self._render_combatant(view.player)
-        self._render_combatant(view.enemy)
-        for entry in view.log_entries:
-            for line in self._log_lines(entry):
-                self._output(line)
-
-        if view.interaction_phase == InteractionPhase.ACTIONS:
-            self._output("Choose an action:")
-            for option in view.action_options:
-                suffix = "" if option.enabled else " [Unavailable]"
-                self._output(f"{option.number}. {option.label}{suffix}")
-        else:
-            self._output(self._phase_heading(view.interaction_phase))
-            for move in view.move_options:
-                tags = " | ".join(move.tags)
-                suffix = "" if move.enabled else " [Unavailable]"
-                self._output(f"{move.number}. {move.name} [{tags}]{suffix}")
-                for line in textwrap.wrap(
-                    move.rules_summary,
-                    width=max(20, self._width_provider() - 3),
-                    break_long_words=False,
-                    break_on_hyphens=False,
-                ):
-                    self._output(f"   {line}")
-            self._output("0. Back")
-
-        meter = view.super_meter
-        ready = " READY [S]" if meter.activation_offered else ""
-        self._output(f"Super: {meter.current}/{meter.maximum}{ready}")
+        width = max(30, int(self._width_provider()))
+        lines = (
+            self._framed_lines(view, width)
+            if width >= 60
+            else self._linear_lines(view, width)
+        )
+        if self._interactive and self._ansi_enabled:
+            lines = ("\033[2J\033[H" + lines[0], *lines[1:])
+        for line in lines:
+            self._output(line)
 
     def read_input(self, view):
         if not isinstance(view, BattleView):
@@ -107,23 +105,183 @@ class TerminalBattleUI:
             return None
         return None
 
-    def _render_combatant(self, combatant):
-        self._output(
-            f"{combatant.display_name} HP: "
-            f"{combatant.hp_current}/{combatant.hp_maximum}"
+    def _framed_lines(self, view, width):
+        chars = self._frame_characters()
+        lines = [chars["top_left"] + chars["horizontal"] * (width - 2) + chars["top_right"]]
+        sections = (
+            self._status_lines(view, width - 4),
+            self._visual_lines(view, width - 4),
+            self._display_log_lines(view, width - 4),
+            self._control_lines(view, width - 4),
+            (self._super_meter_line(view, width - 4),),
         )
+        for section_index, section in enumerate(sections):
+            if section_index:
+                lines.append(
+                    chars["middle_left"]
+                    + chars["horizontal"] * (width - 2)
+                    + chars["middle_right"]
+                )
+            for content in section:
+                lines.append(self._boxed_line(content, width, chars["vertical"]))
+        lines.append(chars["bottom_left"] + chars["horizontal"] * (width - 2) + chars["bottom_right"])
+        return tuple(lines)
+
+    def _linear_lines(self, view, width):
+        lines = ["STATUS"]
+        lines.extend(self._combatant_status(view.player, include_super=False))
+        lines.extend(self._combatant_status(view.enemy, include_super=True))
+        lines.append("VISUALS")
+        lines.extend(self._visual_lines(view, width))
+        lines.append("BATTLE LOG")
+        lines.extend(self._display_log_lines(view, width))
+        lines.append("ACTIONS")
+        lines.extend(self._control_lines(view, width))
+        lines.append(self._super_meter_line(view, width))
+        return tuple(
+            wrapped
+            for line in lines
+            for wrapped in self._wrap(line, width)
+        )
+
+    def _status_lines(self, view, width):
+        player_lines = self._combatant_status(view.player, include_super=False)
+        enemy_lines = self._combatant_status(view.enemy, include_super=True)
+        separator = " │ " if self._unicode_enabled else " | "
+        left_width = (width - len(separator)) // 2
+        right_width = width - len(separator) - left_width
+        rows = []
+        for index in range(max(len(player_lines), len(enemy_lines))):
+            left = player_lines[index] if index < len(player_lines) else ""
+            right = enemy_lines[index] if index < len(enemy_lines) else ""
+            rows.append(
+                self._fit(left, left_width).ljust(left_width)
+                + separator
+                + self._fit(right, right_width)
+            )
+        return tuple(rows)
+
+    @staticmethod
+    def _combatant_status(combatant, *, include_super):
+        lines = [combatant.display_name, f"HP {combatant.hp_current}/{combatant.hp_maximum}"]
         if combatant.mana_current is not None:
-            self._output(
-                f"{combatant.display_name} Mana: "
-                f"{combatant.mana_current}/{combatant.mana_maximum}"
+            lines.append(f"Mana {combatant.mana_current}/{combatant.mana_maximum}")
+        if include_super and combatant.super_current is not None:
+            lines.append(f"Super {combatant.super_current}/{combatant.super_maximum}")
+        if combatant.temporary_labels:
+            lines.append("State: " + ", ".join(combatant.temporary_labels))
+        return tuple(lines)
+
+    def _visual_lines(self, view, width):
+        if view.visual.player_lines or view.visual.enemy_lines:
+            player = " ".join(view.visual.player_lines) or view.player.display_name
+            enemy = " ".join(view.visual.enemy_lines) or view.enemy.display_name
+        else:
+            player = f"[ {view.player.display_name} ]"
+            enemy = f"[ {view.enemy.display_name} ]"
+        return (self._fit(f"{player}   VS   {enemy}", width).center(width),)
+
+    def _display_log_lines(self, view, width):
+        lines = []
+        for entry in view.log_entries:
+            for semantic_line in self._log_lines(entry):
+                lines.extend(self._wrap(semantic_line, width))
+        visible_count = 5 if width >= 76 else 3
+        return tuple(lines[-visible_count:] or ("Battle awaits.",))
+
+    def _control_lines(self, view, width):
+        if view.interaction_phase == InteractionPhase.ACTIONS:
+            labels = tuple(
+                f"{option.number}. {option.label}"
+                + (" [Unavailable]" if not option.enabled else "")
+                for option in view.action_options
             )
-        if combatant.super_current is not None:
-            self._output(
-                f"{combatant.display_name} Super: "
-                f"{combatant.super_current}/{combatant.super_maximum}"
+            first_row = "   ".join(labels[:3])
+            second_row = "   ".join(labels[3:])
+            return (
+                "Actions",
+                *self._wrap(first_row, width),
+                *self._wrap(second_row, width),
             )
-        for label in combatant.temporary_labels:
-            self._output(f"{combatant.display_name} {label}: yes")
+
+        lines = [self._phase_heading(view.interaction_phase)]
+        for move in view.move_options:
+            tags = " | ".join(move.tags)
+            suffix = " [Unavailable]" if not move.enabled else ""
+            lines.extend(
+                self._wrap(
+                    f"{move.number}. {move.name} [{tags}]{suffix}",
+                    width,
+                )
+            )
+            lines.extend(
+                "   " + summary_line
+                for summary_line in self._wrap(move.rules_summary, max(20, width - 3))
+            )
+        lines.append("0. Back")
+        return tuple(lines)
+
+    def _super_meter_line(self, view, width):
+        meter = view.super_meter
+        suffix = f" {meter.current}/{meter.maximum}"
+        if meter.activation_offered:
+            suffix += " READY [S]"
+        prefix = "SUPER "
+        bar_width = max(8, width - len(prefix) - len(suffix) - 2)
+        filled = bar_width * meter.fill_bps // 10_000
+        if self._unicode_enabled:
+            bar = "█" * filled + "░" * (bar_width - filled)
+        else:
+            bar = "#" * filled + "-" * (bar_width - filled)
+        return self._fit(f"{prefix}[{bar}]{suffix}", width)
+
+    def _frame_characters(self):
+        if self._unicode_enabled:
+            return {
+                "top_left": "┌",
+                "top_right": "┐",
+                "bottom_left": "└",
+                "bottom_right": "┘",
+                "middle_left": "├",
+                "middle_right": "┤",
+                "horizontal": "─",
+                "vertical": "│",
+            }
+        return {
+            "top_left": "+",
+            "top_right": "+",
+            "bottom_left": "+",
+            "bottom_right": "+",
+            "middle_left": "+",
+            "middle_right": "+",
+            "horizontal": "-",
+            "vertical": "|",
+        }
+
+    @staticmethod
+    def _boxed_line(content, width, vertical):
+        inner_width = width - 4
+        return f"{vertical} {content[:inner_width].ljust(inner_width)} {vertical}"
+
+    @staticmethod
+    def _fit(value, width):
+        if len(value) <= width:
+            return value
+        if width <= 3:
+            return value[:width]
+        return value[: width - 3] + "..."
+
+    @staticmethod
+    def _wrap(value, width):
+        return tuple(
+            textwrap.wrap(
+                value,
+                width=max(1, width),
+                break_long_words=True,
+                break_on_hyphens=False,
+            )
+            or ("",)
+        )
 
     @staticmethod
     def _phase_heading(phase):

--- a/tests/smoke_test_vertical_slice.py
+++ b/tests/smoke_test_vertical_slice.py
@@ -74,7 +74,8 @@ def test_attack_path_reaches_victory_ending():
     assert "You have chosen Joruun Veyr, the Bloody Storm Monk!" in text
     assert "You ready your weapon" in text
     assert "A Goblin blocks your path" in text
-    assert "Joruun Veyr HP:" in text
+    assert "Joruun Veyr" in text
+    assert "HP 100/100" in text
     assert "Victory. Your adventure has begun." in text
 
 

--- a/tests/test_battle_player_state.py
+++ b/tests/test_battle_player_state.py
@@ -3,7 +3,7 @@ import contextlib
 import io
 import random
 from types import SimpleNamespace
-from app.combat.battle import Battle
+from app.combat.battle import Battle as DomainBattle
 from app.combat.move import (
     DamageType,
     Move,
@@ -25,6 +25,7 @@ from app.presentation.battle_models import (
     InteractionPhase,
 )
 from app.ui.battle_ui import ChooseAction, ChooseMove, GoBack
+from app.ui.terminal_battle_ui import TerminalBattleUI
 from app.world.character_profiles.roster import get_profile_by_choice
 
 
@@ -130,6 +131,17 @@ class ScriptedBattleUI:
     def read_input(self, view):
         self.input_views.append(view)
         return self.inputs.pop(0)
+
+
+class Battle(DomainBattle):
+    def __init__(self, player_state, foe, resolver=None, ui=None, **kwargs):
+        super().__init__(
+            player_state,
+            foe,
+            ui=ui or TerminalBattleUI(),
+            resolver=resolver,
+            **kwargs,
+        )
 
 
 class LegacyMovesFailingEnemyState(EnemyState):

--- a/tests/test_battle_player_state.py
+++ b/tests/test_battle_player_state.py
@@ -4,13 +4,27 @@ import io
 import random
 from types import SimpleNamespace
 from app.combat.battle import Battle
-from app.combat.move import TargetType
+from app.combat.move import (
+    DamageType,
+    Move,
+    MoveKind,
+    ResourceType,
+    ScalingAttribute,
+    TargetType,
+)
 from app.combat.resolver import CombatResolver
 from app.combat.result import MoveResult
 from app.enemies.goblin.definition import Goblin
 from app.enemies.state import EnemyState
 from app.player.character import Brawler, Monk
 from app.player.player_state import PlayerState
+from app.presentation.battle_models import (
+    ActionIntent,
+    BattleEventType,
+    InputRejectionReason,
+    InteractionPhase,
+)
+from app.ui.battle_ui import ChooseAction, ChooseMove, GoBack
 from app.world.character_profiles.roster import get_profile_by_choice
 
 
@@ -104,6 +118,20 @@ class RecordingResolver:
         return self._defend_results.pop(0) if self._defend_results else accepted_result()
 
 
+class ScriptedBattleUI:
+    def __init__(self, *inputs):
+        self.inputs = list(inputs)
+        self.rendered_views = []
+        self.input_views = []
+
+    def render(self, view):
+        self.rendered_views.append(view)
+
+    def read_input(self, view):
+        self.input_views.append(view)
+        return self.inputs.pop(0)
+
+
 class LegacyMovesFailingEnemyState(EnemyState):
     @property
     def moves(self):
@@ -146,6 +174,130 @@ def test_battle_accepts_injected_resolver():
     battle = Battle(PlayerState(Brawler()), EnemyState(Goblin()), resolver=resolver)
 
     assert battle.resolver is resolver
+
+
+def test_battle_accepts_injected_semantic_ui():
+    ui = ScriptedBattleUI(
+        ChooseAction(ActionIntent.ATTACK),
+        ChooseMove("Crestgrave Reaping"),
+    )
+    resolver = RecordingResolver(accepted_result())
+    battle = Battle(
+        PlayerState(Brawler()),
+        EnemyState(Goblin()),
+        resolver=resolver,
+        ui=ui,
+    )
+
+    accepted = battle.player_action()
+
+    assert accepted is True
+    assert tuple(view.interaction_phase for view in ui.input_views) == (
+        InteractionPhase.ACTIONS,
+        InteractionPhase.REGULAR_MOVES,
+    )
+    assert resolver.calls[0]["move_name"] == "Crestgrave Reaping"
+
+
+def test_unoffered_semantic_action_never_reaches_resolver_or_advances():
+    ui = ScriptedBattleUI(
+        ChooseAction(ActionIntent.ITEMS),
+        ChooseAction(ActionIntent.DEFEND),
+    )
+    resolver = RecordingResolver(defend_results=(accepted_result(),))
+    battle = Battle(
+        PlayerState(Brawler()),
+        EnemyState(Goblin()),
+        resolver=resolver,
+        ui=ui,
+    )
+
+    assert battle.player_action() is True
+
+    assert resolver.calls == []
+    assert len(resolver.defend_calls) == 1
+    assert battle.combat_state.turn_count == 1
+    rejection = battle.presentation_session.entries[0]
+    assert rejection.event_type == BattleEventType.INPUT_REJECTED
+    assert rejection.rejection_reason == InputRejectionReason.ACTION_UNAVAILABLE
+
+
+def test_go_back_changes_phase_without_resolver_or_lifecycle_completion():
+    ui = ScriptedBattleUI(
+        ChooseAction(ActionIntent.ATTACK),
+        GoBack(),
+        ChooseAction(ActionIntent.DEFEND),
+    )
+    resolver = RecordingResolver(defend_results=(accepted_result(),))
+    battle = Battle(
+        PlayerState(Brawler()),
+        EnemyState(Goblin()),
+        resolver=resolver,
+        ui=ui,
+    )
+
+    assert battle.player_action() is True
+
+    assert tuple(view.interaction_phase for view in ui.input_views) == (
+        InteractionPhase.ACTIONS,
+        InteractionPhase.REGULAR_MOVES,
+        InteractionPhase.ACTIONS,
+    )
+    assert resolver.calls == []
+    assert battle.combat_state.turn_count == 1
+
+
+def test_super_opens_from_regular_move_phase_without_advancing():
+    player_state = PlayerState(Brawler())
+    player_state.super_resource.gain(100)
+    super_move = player_state.combat_moves[-1]
+    ui = ScriptedBattleUI(
+        ChooseAction(ActionIntent.ATTACK),
+        ChooseAction(ActionIntent.SUPER),
+        ChooseMove(super_move.name),
+    )
+    resolver = RecordingResolver(accepted_result())
+    battle = Battle(
+        player_state,
+        EnemyState(Goblin()),
+        resolver=resolver,
+        ui=ui,
+    )
+
+    assert battle.player_action() is True
+
+    assert tuple(view.interaction_phase for view in ui.input_views) == (
+        InteractionPhase.ACTIONS,
+        InteractionPhase.REGULAR_MOVES,
+        InteractionPhase.SUPER_MOVES,
+    )
+    assert resolver.calls[0]["move_name"] == super_move.name
+    assert battle.combat_state.turn_count == 1
+
+
+def test_resolver_rejection_retains_move_phase_until_accepted():
+    ui = ScriptedBattleUI(
+        ChooseAction(ActionIntent.ATTACK),
+        ChooseMove("Crestgrave Reaping"),
+        ChooseMove("Crestgrave Reaping"),
+    )
+    resolver = RecordingResolver(rejected_result(), accepted_result())
+    battle = Battle(
+        PlayerState(Brawler()),
+        EnemyState(Goblin()),
+        resolver=resolver,
+        ui=ui,
+    )
+
+    assert battle.player_action() is True
+
+    assert tuple(view.interaction_phase for view in ui.input_views) == (
+        InteractionPhase.ACTIONS,
+        InteractionPhase.REGULAR_MOVES,
+        InteractionPhase.REGULAR_MOVES,
+    )
+    assert len(resolver.calls) == 2
+    assert battle.combat_state.turn_count == 1
 
 
 def test_structured_move_helpers_read_player_and_enemy_combat_moves():
@@ -191,62 +343,64 @@ def test_complete_accepted_action_does_nothing_when_result_is_rejected():
     assert battle.combat_state.is_defending(enemy_state)
 
 
-def test_result_renderer_prints_critical_damage_and_preserves_other_result_rendering():
+def test_move_results_become_structured_semantic_events():
     battle = Battle(PlayerState(Brawler()), EnemyState(Goblin()))
-    output = io.StringIO()
 
-    with contextlib.redirect_stdout(output):
-        battle._render_move_result(
-            result_with(move_name="Cut", damage=7),
-            actor=battle.player_state,
-            target=battle.foe,
-        )
-        battle._render_move_result(
-            result_with(move_name="Smash", damage=16, critical=True),
-            actor=battle.player_state,
-            target=battle.foe,
-        )
-        battle._render_move_result(
-            result_with(move_name="Recover", healing=3),
-            actor=battle.player_state,
-            target=battle.player_state,
-        )
-        battle._render_move_result(
-            result_with(move_name="Whiff", hit=False),
-            actor=battle.foe,
-            target=battle.player_state,
-        )
-        battle._render_move_result(
-            rejected_result(),
-            actor=battle.player_state,
-            target=battle.foe,
-        )
-        battle._render_move_result(
-            result_with(
-                move_name="Spark",
-                resource_spent=4,
-                statuses_applied=("burn", "shock"),
-            ),
-            actor=battle.player_state,
-            target=battle.foe,
-        )
-        battle._render_move_result(
-            result_with(move_name="Defend", hit=False),
-            actor=battle.player_state,
-        )
+    battle._record_move_result(
+        result_with(move_name="Cut", damage=7),
+        actor=battle.player_state,
+        target=battle.foe,
+    )
+    battle._record_move_result(
+        result_with(move_name="Smash", damage=16, critical=True),
+        actor=battle.player_state,
+        target=battle.foe,
+    )
+    battle._record_move_result(
+        result_with(move_name="Recover", healing=3),
+        actor=battle.player_state,
+        target=battle.player_state,
+    )
+    battle._record_move_result(
+        result_with(move_name="Whiff", hit=False),
+        actor=battle.foe,
+        target=battle.player_state,
+    )
+    battle._record_move_result(
+        rejected_result(),
+        actor=battle.player_state,
+        target=battle.foe,
+    )
+    battle._record_move_result(
+        result_with(
+            move_name="Spark",
+            resource_spent=4,
+            statuses_applied=("burn", "shock"),
+        ),
+        actor=battle.player_state,
+        target=battle.foe,
+    )
+    battle._record_move_result(
+        result_with(move_name="Defend", hit=False),
+        actor=battle.player_state,
+        event_type=BattleEventType.DEFEND,
+    )
 
-    text = output.getvalue()
-    assert "Brawler used Cut. It dealt 7 damage." in text
-    assert "Brawler used Smash. Critical hit! It dealt 16 damage." in text
-    assert "Brawler used Recover. It restored 3 health." in text
-    assert "Goblin used Whiff, but missed." in text
-    assert "Brawler used test move, but it failed: rejected." in text
-    assert "Resource spent: 4." in text
-    assert "Statuses applied: burn, shock." in text
-    assert "Brawler used Defend." in text
-    assert "Defend missed" not in text
-    assert "Whiff. It dealt" not in text
-    assert "Brawler used Cut. Critical hit!" not in text
+    entries = battle.presentation_session.entries
+    assert tuple(entry.event_type for entry in entries) == (
+        BattleEventType.DAMAGE,
+        BattleEventType.DAMAGE,
+        BattleEventType.HEALING,
+        BattleEventType.MISS,
+        BattleEventType.ACTION_REJECTED,
+        BattleEventType.UTILITY,
+        BattleEventType.DEFEND,
+    )
+    assert entries[0].amount == 7 and entries[0].critical is False
+    assert entries[1].amount == 16 and entries[1].critical is True
+    assert entries[4].reason == "rejected"
+    assert entries[5].resource_spent == 4
+    assert entries[5].statuses_applied == ("burn", "shock")
 
 
 def test_player_main_menu_shows_structured_actions_without_legacy_recover_or_labels():
@@ -259,8 +413,10 @@ def test_player_main_menu_shows_structured_actions_without_legacy_recover_or_lab
     text = output.getvalue()
     assert "1. Attack" in text
     assert "2. Defend" in text
-    assert "3. Items" in text
-    assert "4. Super" in text
+    assert "3. Heal [Unavailable]" in text
+    assert "4. Items [Unavailable]" in text
+    assert "5. Escape [Unavailable]" in text
+    assert "Super: 0/100" in text
     assert "Recover (restore health)" not in text
     assert "steady attack" not in text
     assert "risky heavy attack" not in text
@@ -288,8 +444,10 @@ def test_attack_submenu_displays_non_super_structured_moves_with_resources_and_d
 
     for index, move in enumerate(non_super_moves, start=1):
         assert f"{index}. {move.name}" in text
-        assert f"[{move.resource_type.value} {move.resource_cost}]" in text
-        assert move.description in text
+        assert move.description in text or (
+            move.presentation is not None
+            and move.presentation.static_summary in text
+        )
 
     assert "0. Back" in text
     assert all(move.name not in text for move in super_moves)
@@ -297,6 +455,7 @@ def test_attack_submenu_displays_non_super_structured_moves_with_resources_and_d
 
 def test_super_submenu_displays_super_move_separately_and_routes_to_resolver():
     player_state = PlayerState(Brawler())
+    player_state.super_resource.gain(100)
     resolver = RecordingResolver(rejected_result(), accepted_result())
     battle = Battle(player_state, EnemyState(Goblin()), resolver=resolver)
     output = io.StringIO()
@@ -313,7 +472,7 @@ def test_super_submenu_displays_super_move_separately_and_routes_to_resolver():
 
     assert "Choose a Super:" in text
     assert f"1. {super_move.name}" in text
-    assert f"[{super_move.resource_type.value} {super_move.resource_cost}]" in text
+    assert "[Super | 100 Super]" in text
     assert super_move.description in text
     assert "Brawler used test move, but it failed: rejected." in text
     assert battle.combat_state.turn_count == 1
@@ -333,8 +492,8 @@ def test_items_are_unavailable_and_return_to_main_menu_without_advancing_until_a
         battle.player_action()
 
     text = output.getvalue()
-    assert "Items are not available yet." in text
-    assert text.count("Choose an action:") == 2
+    assert "Items is not available." in text
+    assert text.count("Choose an action:") == 1
     assert battle.combat_state.turn_count == 1
 
 
@@ -429,15 +588,17 @@ def test_player_menu_display_does_not_depend_on_legacy_character_moves():
 
 
 def test_attack_and_super_submenus_support_back_and_reprompt_invalid_input():
-    battle = Battle(PlayerState(Brawler()), EnemyState(Goblin()))
+    player_state = PlayerState(Brawler())
+    player_state.super_resource.gain(100)
+    battle = Battle(player_state, EnemyState(Goblin()))
     output = io.StringIO()
 
     with patched_battle(inputs=["attack", "bad", "0", "super", "bad", "0", "attack", "1"]), contextlib.redirect_stdout(output):
         battle.player_action()
 
     text = output.getvalue()
-    assert text.count("Choose an attack:") == 3
-    assert text.count("Choose a Super:") == 2
+    assert text.count("Choose a move:") == 2
+    assert text.count("Choose a Super:") == 1
     assert text.count("That is not a valid move. Please try again.") == 2
     assert battle.combat_state.turn_count == 1
 
@@ -497,12 +658,18 @@ def test_legacy_battle_combat_helpers_are_removed():
 
 def test_self_targeting_player_move_routes_player_state_to_resolver():
     player_state = PlayerState(Brawler())
-    self_move = SimpleNamespace(
+    self_move = Move(
         name="test self move",
-        resource_type=SimpleNamespace(value="none"),
+        kind=MoveKind.UTILITY,
+        resource_type=ResourceType.NONE,
         resource_cost=0,
-        description="A test self-targeting move.",
+        power=0,
+        scales_with=(ScalingAttribute.NONE,),
+        accuracy=100,
         target=TargetType.SELF,
+        damage_type=DamageType.NONE,
+        mechanic=None,
+        description="A test self-targeting move.",
     )
     player_state.character.combat_moves = [self_move]
     resolver = RecordingResolver(accepted_result())
@@ -555,7 +722,7 @@ def test_battles_do_not_share_combat_state():
     assert second_battle.combat_state.statuses == {}
 
 
-def test_hud_prints_resources_and_temporary_state_when_relevant():
+def test_battle_view_contains_resources_and_temporary_state_when_relevant():
     player_state = PlayerState(Brawler())
     enemy_state = ManaBearingEnemyState(Goblin())
     battle = Battle(player_state, enemy_state)
@@ -564,39 +731,25 @@ def test_hud_prints_resources_and_temporary_state_when_relevant():
     enemy_state.super_resource.gain(20)
     battle.combat_state.activate_defend(player_state)
     battle.combat_state.activate_defend(enemy_state)
-    battle.combat_state.statuses["burn"] = 1
-    battle.combat_state.buffs["guard"] = 1
-    battle.combat_state.debuffs["slow"] = 1
-    output = io.StringIO()
+    view = battle._build_view()
 
-    with contextlib.redirect_stdout(output):
-        battle.print_health()
-
-    text = output.getvalue()
-    assert "Brawler HP:" in text
-    assert "Brawler Mana:" in text
-    assert "Brawler Super: 10/100" in text
-    assert "Brawler Defending: yes" in text
-    assert "Goblin HP: 60/60" in text
-    assert "Goblin Mana: 3/5" in text
-    assert "Goblin Super: 20/100" in text
-    assert "Goblin Defending: yes" in text
-    assert "Statuses: {'burn': 1}" in text
-    assert "Buffs: {'guard': 1}" in text
-    assert "Debuffs: {'slow': 1}" in text
+    assert (view.player.hp_current, view.player.hp_maximum) == (116, 116)
+    assert (view.player.mana_current, view.player.mana_maximum) == (44, 46)
+    assert (view.player.super_current, view.player.super_maximum) == (10, 100)
+    assert view.player.temporary_labels == ("Defending",)
+    assert (view.enemy.hp_current, view.enemy.hp_maximum) == (60, 60)
+    assert (view.enemy.mana_current, view.enemy.mana_maximum) == (3, 5)
+    assert (view.enemy.super_current, view.enemy.super_maximum) == (20, 100)
+    assert view.enemy.temporary_labels == ("Defending",)
 
 
-def test_hud_omits_enemy_mana_and_super_when_not_relevant():
+def test_battle_view_omits_enemy_mana_and_super_when_not_relevant():
     battle = Battle(PlayerState(Brawler()), EnemyState(Goblin()))
-    output = io.StringIO()
+    view = battle._build_view()
 
-    with contextlib.redirect_stdout(output):
-        battle.print_health()
-
-    text = output.getvalue()
-    assert "Goblin HP: 60/60" in text
-    assert "Goblin Mana:" not in text
-    assert "Goblin Super:" not in text
+    assert (view.enemy.hp_current, view.enemy.hp_maximum) == (60, 60)
+    assert view.enemy.mana_current is None
+    assert view.enemy.super_current is None
 
 
 def test_enemy_action_routes_authored_combat_move_through_resolver():
@@ -733,27 +886,20 @@ def test_low_health_enemy_does_not_use_universal_recovery_branch():
     assert len(resolver.calls) == 1
 
 
-def test_battle_player_output_uses_canonical_short_identity_when_profile_attached():
+def test_battle_presentation_uses_canonical_short_identity_when_profile_attached():
     character = get_profile_by_choice("1").create_character()
     player_state = PlayerState(character)
     battle = Battle(player_state, EnemyState(Goblin()))
-    output = io.StringIO()
+    battle._record_move_result(
+        result_with(move_name="Crestgrave Reaping", damage=12),
+        actor=battle.player_state,
+        target=battle.foe,
+    )
+    view = battle._build_view()
 
-    with contextlib.redirect_stdout(output):
-        battle.print_health()
-        battle._render_move_result(
-            result_with(move_name="Crestgrave Reaping", damage=12),
-            actor=battle.player_state,
-            target=battle.foe,
-        )
-
-    text = output.getvalue()
-    assert "Ser Branoc HP:" in text
-    assert "Ser Branoc Mana:" in text
-    assert "Ser Branoc Super:" in text
-    assert "Ser Branoc used Crestgrave Reaping." in text
-    assert "Brawler HP:" not in text
-    assert "Brawler used Crestgrave Reaping" not in text
+    assert view.player.display_name == "Ser Branoc"
+    assert view.log_entries[-1].actor_name == "Ser Branoc"
+    assert view.player.display_name != "Brawler"
 
 
 def test_battle_starts_from_existing_persistent_health():

--- a/tests/test_battle_player_state.py
+++ b/tests/test_battle_player_state.py
@@ -577,19 +577,33 @@ def test_rejected_player_defend_reprompts_without_completion_or_turn_advance():
     assert battle.combat_state.turn_count == 1
 
 
-def test_rejected_player_move_does_not_clear_defend_or_advance_before_backing_out():
+def test_rejected_player_move_preserves_lifecycle_through_back_navigation():
     player_state = PlayerState(Brawler())
     enemy_state = EnemyState(Goblin())
     resolver = RecordingResolver(rejected_result())
-    battle = Battle(player_state, enemy_state, resolver=resolver)
+    inputs = [
+        ChooseAction(ActionIntent.ATTACK),
+        ChooseMove(player_state.combat_moves[0].name),
+        GoBack(),
+        ChooseAction(ActionIntent.DEFEND),
+    ]
+
+    class LifecycleInspectingUI(ScriptedBattleUI):
+        def read_input(self, view):
+            if len(self.input_views) in (2, 3):
+                assert battle.combat_state.turn_count == 0
+                assert battle.combat_state.is_defending(enemy_state)
+            return super().read_input(view)
+
+    ui = LifecycleInspectingUI(*inputs)
+    battle = Battle(player_state, enemy_state, resolver=resolver, ui=ui)
     battle.combat_state.activate_defend(enemy_state)
 
-    with patched_battle(inputs=["1", "0"]), contextlib.redirect_stdout(io.StringIO()):
-        accepted = battle._player_attack_menu()
+    accepted = battle.player_action()
 
-    assert accepted is False
-    assert battle.combat_state.turn_count == 0
-    assert battle.combat_state.is_defending(enemy_state)
+    assert accepted is True
+    assert battle.combat_state.turn_count == 1
+    assert not battle.combat_state.is_defending(enemy_state)
 
 
 def test_defend_is_not_a_structured_combat_move():

--- a/tests/test_battle_player_state.py
+++ b/tests/test_battle_player_state.py
@@ -4,6 +4,7 @@ import io
 import random
 from types import SimpleNamespace
 from app.combat.battle import Battle as DomainBattle
+from app.combat.brace import BRACE_RULES
 from app.combat.move import (
     DamageType,
     Move,
@@ -456,10 +457,20 @@ def test_attack_submenu_displays_non_super_structured_moves_with_resources_and_d
 
     for index, move in enumerate(non_super_moves, start=1):
         assert f"{index}. {move.name}" in text
-        assert move.description in text or (
-            move.presentation is not None
-            and move.presentation.static_summary in text
-        )
+        if move.mechanic == "brace":
+            assert (
+                f"reducing physical damage by {BRACE_RULES.incoming_reduction_percent}%"
+                in text
+            )
+            assert (
+                f"empower your next Heavy attack by "
+                f"{BRACE_RULES.follow_up_damage_bonus_percent}%"
+                in text
+            )
+        elif move.presentation is not None and move.presentation.static_summary is not None:
+            assert move.presentation.static_summary in text
+        else:
+            assert move.description in text
 
     assert "0. Back" in text
     assert all(move.name not in text for move in super_moves)

--- a/tests/test_battle_player_state.py
+++ b/tests/test_battle_player_state.py
@@ -429,7 +429,8 @@ def test_player_main_menu_shows_structured_actions_without_legacy_recover_or_lab
     assert "3. Heal [Unavailable]" in text
     assert "4. Items [Unavailable]" in text
     assert "5. Escape [Unavailable]" in text
-    assert "Super: 0/100" in text
+    assert "SUPER [" in text
+    assert "0/100" in text
     assert "Recover (restore health)" not in text
     assert "steady attack" not in text
     assert "risky heavy attack" not in text
@@ -496,7 +497,8 @@ def test_super_submenu_displays_super_move_separately_and_routes_to_resolver():
     assert "Choose a Super:" in text
     assert f"1. {super_move.name}" in text
     assert "[Super | 100 Super]" in text
-    assert super_move.description in text
+    assert "A forbidden gate manifests" in text
+    assert "Sunder-Spire" in text
     assert "Brawler used test move, but it failed: rejected." in text
     assert battle.combat_state.turn_count == 1
     assert resolver.calls[0] == {
@@ -516,7 +518,7 @@ def test_items_are_unavailable_and_return_to_main_menu_without_advancing_until_a
 
     text = output.getvalue()
     assert "Items is not available." in text
-    assert text.count("Choose an action:") == 1
+    assert text.count("Actions") == 1
     assert battle.combat_state.turn_count == 1
 
 

--- a/tests/test_battle_presentation_models.py
+++ b/tests/test_battle_presentation_models.py
@@ -1,0 +1,206 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from app.presentation.battle_models import (
+    ActionAvailabilityReason,
+    ActionIntent,
+    ActionOptionView,
+    BattleEventType,
+    BattleLogEntry,
+    BattleView,
+    BattleVisualView,
+    CombatantView,
+    InputRejectionReason,
+    InteractionPhase,
+    MoveAvailabilityReason,
+    MoveOptionView,
+    SuperMeterView,
+)
+
+
+def _combatant(**overrides):
+    values = {
+        "display_name": "Ser Branoc",
+        "hp_current": 116,
+        "hp_maximum": 116,
+        "mana_current": 46,
+        "mana_maximum": 46,
+        "super_current": 10,
+        "super_maximum": 100,
+    }
+    values.update(overrides)
+    return CombatantView(**values)
+
+
+def _meter(**overrides):
+    values = {
+        "current": 10,
+        "maximum": 100,
+        "fill_bps": 1000,
+        "ready": False,
+        "activation_key": "S",
+        "activation_offered": False,
+    }
+    values.update(overrides)
+    return SuperMeterView(**values)
+
+
+def _view(**overrides):
+    values = {
+        "interaction_phase": InteractionPhase.ACTIONS,
+        "player": _combatant(),
+        "enemy": _combatant(
+            display_name="Goblin",
+            hp_current=60,
+            hp_maximum=60,
+            mana_current=None,
+            mana_maximum=None,
+            super_current=None,
+            super_maximum=None,
+        ),
+        "super_meter": _meter(),
+    }
+    values.update(overrides)
+    return BattleView(**values)
+
+
+def test_models_are_frozen():
+    models = [
+        _combatant(),
+        ActionOptionView(ActionIntent.ATTACK, 1, "Attack", True),
+        MoveOptionView("Brace", 1, "Brace", ("Utility",), "Brace.", "5 Mana", True),
+        _meter(),
+        BattleLogEntry(BattleEventType.ENCOUNTER_START),
+        BattleVisualView(("player",), ("enemy",)),
+        _view(),
+    ]
+
+    for model in models:
+        with pytest.raises(FrozenInstanceError):
+            setattr(model, "unexpected", True)
+
+
+def test_model_collections_require_tuples():
+    with pytest.raises(TypeError):
+        _combatant(temporary_labels=["Brace"])
+    with pytest.raises(TypeError):
+        MoveOptionView("Brace", 1, "Brace", ["Utility"], "Brace.", "5 Mana", True)
+    with pytest.raises(TypeError):
+        BattleVisualView(["player"], ())
+    with pytest.raises(TypeError):
+        _view(action_options=[])
+    with pytest.raises(TypeError):
+        _view(log_entries=[])
+
+
+def test_resources_reject_negative_or_inconsistent_values():
+    with pytest.raises(ValueError):
+        _combatant(hp_current=-1)
+    with pytest.raises(ValueError):
+        _combatant(hp_current=117)
+    with pytest.raises(ValueError):
+        _combatant(mana_current=1, mana_maximum=None)
+    with pytest.raises(ValueError):
+        _meter(current=101)
+    with pytest.raises(ValueError):
+        _meter(maximum=0)
+    with pytest.raises(ValueError):
+        _meter(fill_bps=10_001)
+
+
+def test_action_and_move_availability_are_explicit():
+    disabled_action = ActionOptionView(
+        ActionIntent.ITEMS,
+        4,
+        "Items",
+        False,
+        ActionAvailabilityReason.NOT_IMPLEMENTED,
+    )
+    disabled_move = MoveOptionView(
+        "Cinderlung Vesper",
+        2,
+        "Cinderlung Vesper",
+        ("Fire Magic", "3 Mana"),
+        "A black war-breath erupts forward.",
+        "3 Mana",
+        False,
+        MoveAvailabilityReason.INSUFFICIENT_RESOURCE,
+    )
+
+    assert disabled_action.disabled_reason == ActionAvailabilityReason.NOT_IMPLEMENTED
+    assert disabled_move.disabled_reason == MoveAvailabilityReason.INSUFFICIENT_RESOURCE
+    with pytest.raises(ValueError):
+        ActionOptionView(ActionIntent.ITEMS, 4, "Items", False)
+    with pytest.raises(ValueError):
+        ActionOptionView(
+            ActionIntent.ATTACK,
+            1,
+            "Attack",
+            True,
+            ActionAvailabilityReason.NO_REGULAR_MOVES,
+        )
+
+
+def test_input_rejection_is_structured_without_terminal_prose():
+    entry = BattleLogEntry(
+        event_type=BattleEventType.INPUT_REJECTED,
+        rejection_reason=InputRejectionReason.ACTION_UNAVAILABLE,
+    )
+
+    assert entry.rejection_reason == InputRejectionReason.ACTION_UNAVAILABLE
+    assert "not available" not in repr(entry)
+    with pytest.raises(ValueError):
+        BattleLogEntry(event_type=BattleEventType.INPUT_REJECTED)
+    with pytest.raises(ValueError):
+        BattleLogEntry(
+            event_type=BattleEventType.DAMAGE,
+            rejection_reason=InputRejectionReason.MOVE_UNAVAILABLE,
+        )
+
+
+def test_battle_log_entry_keeps_semantic_result_values():
+    entry = BattleLogEntry(
+        event_type=BattleEventType.DAMAGE,
+        actor_name="Ser Branoc",
+        target_name="Goblin",
+        action_name="Ironwake Dismemberment",
+        accepted=True,
+        hit=True,
+        amount=21,
+        critical=True,
+        resource_spent=0,
+    )
+
+    assert entry.amount == 21
+    assert entry.critical is True
+    with pytest.raises(ValueError):
+        BattleLogEntry(BattleEventType.DAMAGE, amount=-1)
+
+
+def test_battle_view_contains_only_presentation_values():
+    action = ActionOptionView(ActionIntent.ATTACK, 1, "Attack", True)
+    move = MoveOptionView("Brace", 1, "Brace", ("Utility",), "Brace.", "5 Mana", True)
+    entry = BattleLogEntry(BattleEventType.UTILITY, action_name="Brace", accepted=True, hit=True)
+    view = _view(
+        interaction_phase=InteractionPhase.REGULAR_MOVES,
+        action_options=(action,),
+        move_options=(move,),
+        log_entries=(entry,),
+    )
+
+    assert view.action_options == (action,)
+    assert view.move_options == (move,)
+    assert view.log_entries == (entry,)
+    with pytest.raises(TypeError):
+        _view(player=object())
+    with pytest.raises(TypeError):
+        _view(move_options=(object(),))
+
+
+def test_super_activation_requires_ready_meter():
+    ready = _meter(current=100, fill_bps=10_000, ready=True, activation_offered=True)
+
+    assert ready.activation_key == "S"
+    with pytest.raises(ValueError):
+        _meter(activation_offered=True)

--- a/tests/test_battle_presentation_session.py
+++ b/tests/test_battle_presentation_session.py
@@ -1,0 +1,65 @@
+import pytest
+
+from app.presentation.battle_models import BattleEventType, BattleLogEntry
+from app.presentation.battle_session import (
+    DEFAULT_MAX_LOG_ENTRIES,
+    BattlePresentationSession,
+)
+
+
+def _entry(index):
+    return BattleLogEntry(
+        event_type=BattleEventType.DAMAGE,
+        actor_name="Ser Branoc",
+        target_name="Goblin",
+        action_name=f"move-{index}",
+        accepted=True,
+        hit=True,
+        amount=index,
+    )
+
+
+def test_session_defaults_to_twenty_entries():
+    session = BattlePresentationSession()
+
+    assert session.max_entries == DEFAULT_MAX_LOG_ENTRIES == 20
+    assert session.entries == ()
+
+
+def test_session_retention_discards_oldest_entries_and_preserves_order():
+    session = BattlePresentationSession(max_entries=3)
+
+    for index in range(5):
+        session.record(_entry(index))
+
+    assert tuple(entry.amount for entry in session.entries) == (2, 3, 4)
+
+
+def test_session_exposes_immutable_entry_snapshots():
+    session = BattlePresentationSession()
+    session.record(_entry(1))
+    snapshot = session.entries
+
+    assert isinstance(snapshot, tuple)
+    with pytest.raises(AttributeError):
+        snapshot.append(_entry(2))
+    session.record(_entry(2))
+    assert tuple(entry.amount for entry in snapshot) == (1,)
+    assert tuple(entry.amount for entry in session.entries) == (1, 2)
+
+
+def test_session_accepts_only_semantic_entries():
+    session = BattlePresentationSession()
+
+    with pytest.raises(TypeError):
+        session.record("Ser Branoc dealt damage.")
+    with pytest.raises(TypeError):
+        BattlePresentationSession(max_entries=True)
+    with pytest.raises(ValueError):
+        BattlePresentationSession(max_entries=0)
+
+
+def test_session_owns_no_combat_state():
+    session = BattlePresentationSession()
+
+    assert set(vars(session)) == {"_max_entries", "_entries"}

--- a/tests/test_battle_presenter.py
+++ b/tests/test_battle_presenter.py
@@ -1,0 +1,257 @@
+from app.combat.combat_state import CombatState
+from app.combat.move import (
+    DamageType,
+    Move,
+    MoveKind,
+    ResourceType,
+    ScalingAttribute,
+    TargetType,
+)
+from app.enemies.goblin.definition import Goblin
+from app.enemies.state import EnemyState
+from app.player.character import BlackMage, Brawler
+from app.player.player_state import PlayerState
+from app.presentation.battle_models import (
+    ActionAvailabilityReason,
+    ActionIntent,
+    BattleEventType,
+    BattleLogEntry,
+    InteractionPhase,
+    MoveAvailabilityReason,
+)
+from app.presentation.battle_presenter import BattlePresenter
+
+
+def _battle_values(character=None):
+    player = PlayerState(character or Brawler())
+    enemy = EnemyState(Goblin())
+    combat_state = CombatState()
+    return player, enemy, combat_state
+
+
+def _build(character=None, phase=InteractionPhase.ACTIONS, log_entries=()):
+    player, enemy, combat_state = _battle_values(character)
+    view = BattlePresenter().build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        log_entries=log_entries,
+        interaction_phase=phase,
+    )
+    return view, player, enemy, combat_state
+
+
+def _option(view, intent):
+    return next(option for option in view.action_options if option.intent == intent)
+
+
+def _move(view, name):
+    return next(move for move in view.move_options if move.name == name)
+
+
+def test_presenter_builds_resource_and_temporary_state_views():
+    player, enemy, combat_state = _battle_values()
+    combat_state.activate_defend(player)
+    combat_state.activate_brace(player)
+
+    view = BattlePresenter().build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+    )
+
+    assert (view.player.hp_current, view.player.hp_maximum) == (116, 116)
+    assert (view.player.mana_current, view.player.mana_maximum) == (46, 46)
+    assert (view.player.super_current, view.player.super_maximum) == (0, 100)
+    assert view.player.defending is True
+    assert view.player.temporary_labels == ("Defending", "Brace")
+    assert (view.enemy.hp_current, view.enemy.hp_maximum) == (60, 60)
+    assert view.enemy.mana_current is None
+    assert view.enemy.super_current is None
+
+
+def test_presenter_builds_five_ordinary_action_options():
+    view, _, _, _ = _build()
+
+    assert tuple(option.intent for option in view.action_options) == (
+        ActionIntent.ATTACK,
+        ActionIntent.DEFEND,
+        ActionIntent.HEAL,
+        ActionIntent.ITEMS,
+        ActionIntent.ESCAPE,
+    )
+    assert tuple(option.number for option in view.action_options) == (1, 2, 3, 4, 5)
+    assert _option(view, ActionIntent.ATTACK).enabled is True
+    assert _option(view, ActionIntent.DEFEND).enabled is True
+    assert _option(view, ActionIntent.HEAL).disabled_reason == ActionAvailabilityReason.NO_HEALING_MOVES
+    assert _option(view, ActionIntent.ITEMS).disabled_reason == ActionAvailabilityReason.NOT_IMPLEMENTED
+    assert _option(view, ActionIntent.ESCAPE).disabled_reason == ActionAvailabilityReason.NOT_IMPLEMENTED
+
+
+def test_heal_only_exposes_existing_non_super_healing_moves():
+    character = Brawler()
+    character.combat_moves.append(
+        Move(
+            name="Recover",
+            kind=MoveKind.HEALING,
+            resource_type=ResourceType.MANA,
+            resource_cost=4,
+            power=8,
+            scales_with=(ScalingAttribute.SPIRIT,),
+            accuracy=100,
+            target=TargetType.SELF,
+            damage_type=DamageType.HEALING,
+            mechanic=None,
+            description="Restore health.",
+        )
+    )
+
+    view, _, _, _ = _build(character, InteractionPhase.HEALING_MOVES)
+
+    assert _option(view, ActionIntent.HEAL).enabled is True
+    assert tuple(move.name for move in view.move_options) == ("Recover",)
+    assert view.move_options[0].tags == ("Healing", "4 Mana")
+
+
+def test_interaction_phase_filters_move_categories():
+    actions, _, _, _ = _build(phase=InteractionPhase.ACTIONS)
+    regular, _, _, _ = _build(phase=InteractionPhase.REGULAR_MOVES)
+    healing, _, _, _ = _build(phase=InteractionPhase.HEALING_MOVES)
+    super_moves, _, _, _ = _build(phase=InteractionPhase.SUPER_MOVES)
+
+    assert actions.move_options == ()
+    assert tuple(move.name for move in regular.move_options) == (
+        "Crestgrave Reaping",
+        "Cinderlung Vesper",
+        "Brace",
+        "Ironwake Dismemberment",
+    )
+    assert healing.move_options == ()
+    assert tuple(move.name for move in super_moves.move_options) == (
+        "Third Gate Obsequy",
+    )
+
+
+def test_presenter_composes_authored_tags_summary_and_resource_labels():
+    view, _, _, _ = _build(phase=InteractionPhase.REGULAR_MOVES)
+
+    assert _move(view, "Crestgrave Reaping").tags == ("Normal",)
+    assert _move(view, "Cinderlung Vesper").tags == ("Fire Magic", "3 Mana")
+    assert _move(view, "Brace").tags == ("Utility", "5 Mana")
+    ironwake = _move(view, "Ironwake Dismemberment")
+    assert ironwake.tags == ("Heavy",)
+    assert ironwake.rules_summary == "A crushing Sunder-Spire strike."
+    assert _move(view, "Crestgrave Reaping").rules_summary.startswith("Sunder-Spire")
+
+
+def test_generic_move_metadata_has_deterministic_fallback():
+    view, _, _, _ = _build(BlackMage(), InteractionPhase.REGULAR_MOVES)
+
+    scepter = _move(view, "Scepter Sweep")
+    gloamweight = _move(view, "Gloamweight Sepulcher")
+    assert scepter.tags == ("Normal",)
+    assert scepter.rules_summary == "A direct scepter strike aimed at the target."
+    assert gloamweight.tags == ("Normal", "8 Mana")
+
+
+def test_unaffordable_moves_are_disabled_without_hiding_them():
+    player, enemy, combat_state = _battle_values()
+    player.mana_resource.spend(player.mana_resource.current)
+
+    view = BattlePresenter().build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        interaction_phase=InteractionPhase.REGULAR_MOVES,
+    )
+
+    assert _move(view, "Crestgrave Reaping").enabled is True
+    assert _move(view, "Cinderlung Vesper").disabled_reason == MoveAvailabilityReason.INSUFFICIENT_RESOURCE
+    assert _move(view, "Brace").disabled_reason == MoveAvailabilityReason.INSUFFICIENT_RESOURCE
+
+
+def test_super_meter_is_persistent_and_ready_only_when_affordable():
+    view, player, enemy, combat_state = _build()
+
+    assert (view.super_meter.current, view.super_meter.maximum) == (0, 100)
+    assert view.super_meter.fill_bps == 0
+    assert view.super_meter.ready is False
+    assert view.super_meter.activation_offered is False
+
+    player.super_resource.gain(100)
+    ready = BattlePresenter().build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        interaction_phase=InteractionPhase.REGULAR_MOVES,
+    )
+    assert ready.super_meter.fill_bps == 10_000
+    assert ready.super_meter.ready is True
+    assert ready.super_meter.activation_key == "S"
+    assert ready.super_meter.activation_offered is True
+
+
+def test_brace_follow_up_tag_is_dynamic_non_consuming_and_ordered():
+    player, enemy, combat_state = _battle_values()
+    combat_state.activate_brace(player)
+    presenter = BattlePresenter()
+
+    first = presenter.build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        interaction_phase=InteractionPhase.REGULAR_MOVES,
+    )
+    second = presenter.build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        interaction_phase=InteractionPhase.REGULAR_MOVES,
+    )
+
+    assert _move(first, "Ironwake Dismemberment").tags == ("Heavy", "Empowered +30%")
+    assert first == second
+    assert combat_state.brace_follow_up_damage_bonus_percent(player, "heavy_attack") == 30
+
+
+def test_presenter_preserves_log_snapshot_and_has_no_retained_state():
+    entry = BattleLogEntry(BattleEventType.ENCOUNTER_START)
+    presenter = BattlePresenter()
+    player, enemy, combat_state = _battle_values()
+
+    view = presenter.build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        log_entries=(entry,),
+    )
+
+    assert view.log_entries == (entry,)
+    assert vars(presenter) == {}
+
+
+def test_presenter_build_does_not_mutate_domain_state():
+    player, enemy, combat_state = _battle_values()
+    before = (
+        player.health.current,
+        player.mana_resource.current,
+        player.super_resource.current,
+        enemy.health.current,
+        combat_state.turn_count,
+    )
+
+    BattlePresenter().build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        interaction_phase=InteractionPhase.REGULAR_MOVES,
+    )
+
+    after = (
+        player.health.current,
+        player.mana_resource.current,
+        player.super_resource.current,
+        enemy.health.current,
+        combat_state.turn_count,
+    )
+    assert after == before

--- a/tests/test_battle_presenter.py
+++ b/tests/test_battle_presenter.py
@@ -1,4 +1,5 @@
 from app.combat.combat_state import CombatState
+from app.combat.resolver import CombatResolver
 from app.combat.move import (
     DamageType,
     Move,
@@ -47,6 +48,14 @@ def _option(view, intent):
 
 def _move(view, name):
     return next(move for move in view.move_options if move.name == name)
+
+
+class FixedRng:
+    def __init__(self, *rolls):
+        self.rolls = list(rolls)
+
+    def randint(self, _start, _end):
+        return self.rolls.pop(0)
 
 
 def test_presenter_builds_resource_and_temporary_state_views():
@@ -138,6 +147,10 @@ def test_presenter_composes_authored_tags_summary_and_resource_labels():
     assert _move(view, "Crestgrave Reaping").tags == ("Normal",)
     assert _move(view, "Cinderlung Vesper").tags == ("Fire Magic", "3 Mana")
     assert _move(view, "Brace").tags == ("Utility", "5 Mana")
+    assert _move(view, "Brace").rules_summary == (
+        "Brace against the next enemy action, reducing physical damage by 40%, "
+        "and empower your next Heavy attack by 30%."
+    )
     ironwake = _move(view, "Ironwake Dismemberment")
     assert ironwake.tags == ("Heavy",)
     assert ironwake.rules_summary == "A crushing Sunder-Spire strike."
@@ -212,6 +225,68 @@ def test_brace_follow_up_tag_is_dynamic_non_consuming_and_ordered():
     assert _move(first, "Ironwake Dismemberment").tags == ("Heavy", "Empowered +30%")
     assert first == second
     assert combat_state.brace_follow_up_damage_bonus_percent(player, "heavy_attack") == 30
+
+
+def test_accepted_heavy_hit_and_miss_remove_empowered_tag():
+    for rolls in ((1, 100), (100,)):
+        player, enemy, combat_state = _battle_values()
+        combat_state.activate_brace(player)
+        result = CombatResolver(rng=FixedRng(*rolls)).resolve_move(
+            player,
+            enemy,
+            "Ironwake Dismemberment",
+            combat_state=combat_state,
+        )
+
+        view = BattlePresenter().build(
+            player=player,
+            enemy=enemy,
+            combat_state=combat_state,
+            interaction_phase=InteractionPhase.REGULAR_MOVES,
+        )
+
+        assert result.accepted is True
+        assert "Empowered +30%" not in _move(view, "Ironwake Dismemberment").tags
+
+
+def test_rejected_heavy_and_nonmatching_move_preserve_empowered_tag():
+    player, enemy, combat_state = _battle_values()
+    combat_state.activate_brace(player)
+    enemy.health.take_damage(enemy.health.maximum)
+    rejected = CombatResolver(rng=FixedRng()).resolve_move(
+        player,
+        enemy,
+        "Ironwake Dismemberment",
+        combat_state=combat_state,
+    )
+
+    rejected_view = BattlePresenter().build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        interaction_phase=InteractionPhase.REGULAR_MOVES,
+    )
+
+    assert rejected.accepted is False
+    assert "Empowered +30%" in _move(rejected_view, "Ironwake Dismemberment").tags
+
+    player, enemy, combat_state = _battle_values()
+    combat_state.activate_brace(player)
+    nonmatching = CombatResolver(rng=FixedRng(1, 100)).resolve_move(
+        player,
+        enemy,
+        "Crestgrave Reaping",
+        combat_state=combat_state,
+    )
+    nonmatching_view = BattlePresenter().build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        interaction_phase=InteractionPhase.REGULAR_MOVES,
+    )
+
+    assert nonmatching.accepted is True
+    assert "Empowered +30%" in _move(nonmatching_view, "Ironwake Dismemberment").tags
 
 
 def test_presenter_preserves_log_snapshot_and_has_no_retained_state():

--- a/tests/test_battle_ui_contract.py
+++ b/tests/test_battle_ui_contract.py
@@ -1,0 +1,35 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from app.presentation.battle_models import ActionIntent
+from app.ui.battle_ui import BattleUI, ChooseAction, ChooseMove, GoBack
+
+
+def test_semantic_input_values_are_frozen_and_validated():
+    action = ChooseAction(ActionIntent.ATTACK)
+    move = ChooseMove("Ironwake Dismemberment")
+    back = GoBack()
+
+    assert action.intent == ActionIntent.ATTACK
+    assert move.move_key == "Ironwake Dismemberment"
+    with pytest.raises(FrozenInstanceError):
+        action.intent = ActionIntent.DEFEND
+    with pytest.raises(ValueError):
+        ChooseAction("unsupported")
+    with pytest.raises(ValueError):
+        ChooseMove("")
+    with pytest.raises(TypeError):
+        ChooseMove(1)
+    assert back == GoBack()
+
+
+def test_battle_ui_protocol_is_runtime_checkable():
+    class Adapter:
+        def render(self, view):
+            pass
+
+        def read_input(self, view):
+            return GoBack()
+
+    assert isinstance(Adapter(), BattleUI)

--- a/tests/test_battle_ui_hardening.py
+++ b/tests/test_battle_ui_hardening.py
@@ -133,7 +133,7 @@ def test_battle_source_has_no_direct_terminal_io_or_adapter_dependency():
     assert "terminal_battle_ui" not in source
 
 
-def test_presenter_and_terminal_contracts_do_not_change_combat_resources():
+def test_presenter_observation_does_not_change_combat_resources():
     player = PlayerState(Brawler())
     enemy = EnemyState(Goblin())
     combat_state = CombatState()

--- a/tests/test_battle_ui_hardening.py
+++ b/tests/test_battle_ui_hardening.py
@@ -1,0 +1,177 @@
+import ast
+import inspect
+
+import pytest
+
+import app.combat.battle as battle_module
+from app.combat.battle import Battle
+from app.combat.combat_state import CombatState
+from app.combat.move import TargetType
+from app.combat.resolver import CombatResolver
+from app.enemies.goblin.definition import Goblin
+from app.enemies.state import EnemyState
+from app.player.character import BlackMage, Brawler, Monk, RogueArcher
+from app.player.player_state import PlayerState
+from app.presentation.battle_models import (
+    ActionIntent,
+    BattleEventType,
+    InteractionPhase,
+)
+from app.presentation.battle_presenter import BattlePresenter
+from app.ui.battle_ui import ChooseAction, ChooseMove
+
+
+DRIFTER_TYPES = (Brawler, BlackMage, RogueArcher, Monk)
+
+
+class AlwaysOneRng:
+    @staticmethod
+    def randint(_start, _end):
+        return 1
+
+
+class AggressiveScriptedUI:
+    def __init__(self):
+        self.views = []
+        self.input_count = 0
+
+    def render(self, view):
+        self.views.append(view)
+
+    def read_input(self, view):
+        self.input_count += 1
+        if self.input_count > 100:
+            raise AssertionError("scripted Goblin encounter did not terminate")
+        if view.interaction_phase == InteractionPhase.ACTIONS:
+            return ChooseAction(ActionIntent.ATTACK)
+
+        enabled_moves = [move for move in view.move_options if move.enabled]
+        if not enabled_moves:
+            raise AssertionError("no affordable regular move was offered")
+        return ChooseMove(enabled_moves[-1].selection_key)
+
+
+@pytest.mark.parametrize("character_type", DRIFTER_TYPES)
+def test_every_drifter_move_is_presented_and_resolver_compatible(character_type):
+    player = PlayerState(character_type())
+    enemy = EnemyState(Goblin())
+    combat_state = CombatState()
+    presenter = BattlePresenter()
+
+    regular_view = presenter.build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        interaction_phase=InteractionPhase.REGULAR_MOVES,
+    )
+    super_view = presenter.build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        interaction_phase=InteractionPhase.SUPER_MOVES,
+    )
+    presented_names = {
+        move.selection_key
+        for move in (*regular_view.move_options, *super_view.move_options)
+    }
+
+    assert presented_names == {move.name for move in player.combat_moves}
+
+    for authored_move in player.combat_moves:
+        actor = PlayerState(character_type())
+        target = EnemyState(Goblin())
+        actor.super_resource.gain(actor.super_resource.maximum)
+        resolution_target = actor if authored_move.target == TargetType.SELF else target
+        result = CombatResolver(rng=AlwaysOneRng()).resolve_move(
+            actor,
+            resolution_target,
+            authored_move.name,
+            combat_state=CombatState(),
+        )
+
+        assert result.accepted is True, (
+            character_type.__name__,
+            authored_move.name,
+            result.reason,
+        )
+
+
+@pytest.mark.parametrize("character_type", DRIFTER_TYPES)
+def test_every_drifter_completes_deterministic_goblin_vertical_slice(
+    character_type,
+    monkeypatch,
+):
+    monkeypatch.setattr(battle_module.random, "randint", lambda _start, _end: 1)
+    monkeypatch.setattr(battle_module.random, "choice", lambda moves: moves[0])
+    ui = AggressiveScriptedUI()
+    battle = Battle(
+        PlayerState(character_type()),
+        EnemyState(Goblin()),
+        ui=ui,
+        resolver=CombatResolver(rng=AlwaysOneRng()),
+    )
+
+    winner = battle.run()
+
+    assert winner == "player"
+    assert battle.foe.health.current == 0
+    assert battle.presentation_session.entries[-1].event_type == BattleEventType.VICTORY
+    assert ui.views
+
+
+def test_battle_source_has_no_direct_terminal_io_or_adapter_dependency():
+    source = inspect.getsource(battle_module)
+    tree = ast.parse(source)
+    direct_calls = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+
+    assert "input" not in direct_calls
+    assert "print" not in direct_calls
+    assert "terminal_battle_ui" not in source
+
+
+def test_presenter_and_terminal_contracts_do_not_change_combat_resources():
+    player = PlayerState(Brawler())
+    enemy = EnemyState(Goblin())
+    combat_state = CombatState()
+    combat_state.activate_brace(player)
+    presenter = BattlePresenter()
+    before = (
+        player.health.current,
+        player.mana_resource.current,
+        player.super_resource.current,
+        enemy.health.current,
+        combat_state.turn_count,
+    )
+
+    first = presenter.build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        interaction_phase=InteractionPhase.REGULAR_MOVES,
+    )
+    second = presenter.build(
+        player=player,
+        enemy=enemy,
+        combat_state=combat_state,
+        interaction_phase=InteractionPhase.REGULAR_MOVES,
+    )
+    after = (
+        player.health.current,
+        player.mana_resource.current,
+        player.super_resource.current,
+        enemy.health.current,
+        combat_state.turn_count,
+    )
+
+    assert first == second
+    assert before == after
+    assert vars(presenter) == {}
+    assert any(
+        move.selection_key == "Ironwake Dismemberment"
+        and "Empowered +30%" in move.tags
+        for move in first.move_options
+    )

--- a/tests/test_character_move_data.py
+++ b/tests/test_character_move_data.py
@@ -1,4 +1,5 @@
 from app.combat.move import DamageType, Move, MoveKind, ResourceType, ScalingAttribute, TargetType
+from app.combat.move_presentation import MoveRole
 from app.player.character import BlackMage, Brawler, Monk, RogueArcher
 
 
@@ -168,6 +169,18 @@ def test_brawler_roster_is_four_standard_attacks_and_one_super():
         move.mechanic in {None, "basic_attack", "heavy_attack", "brace"}
         for move in brawler.combat_moves
     )
+    assert [move.presentation.role for move in brawler.combat_moves] == [
+        MoveRole.NORMAL,
+        MoveRole.NORMAL,
+        MoveRole.UTILITY,
+        MoveRole.HEAVY,
+        MoveRole.SUPER,
+    ]
+    assert brawler.combat_moves[1].presentation.affinity_label == "Fire"
+    assert brawler.combat_moves[3].presentation.static_summary == (
+        "A crushing Sunder-Spire strike."
+    )
+    assert all(move.presentation is not None for move in brawler.combat_moves)
 
 
 def test_rogue_archer_roster_is_four_standard_attacks_and_one_super():

--- a/tests/test_combat_state.py
+++ b/tests/test_combat_state.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from app.combat.brace import BRACE_RULES
 from app.combat.move import DamageType
 from app.combat.combat_state import CombatState
 
@@ -7,6 +8,12 @@ from app.combat.combat_state import CombatState
 @dataclass(eq=True, frozen=False)
 class UnhashableCombatant:
     name: str
+
+
+def test_brace_rules_are_the_approved_shared_values():
+    assert BRACE_RULES.incoming_reduction_percent == 40
+    assert BRACE_RULES.follow_up_damage_bonus_percent == 30
+    assert BRACE_RULES.follow_up_mechanic == "heavy_attack"
 
 
 def test_combat_state_starts_with_empty_temporary_state():
@@ -166,6 +173,23 @@ def test_brace_incoming_reduction_query_does_not_consume_state():
     assert combat_state.brace_incoming_reduction_percent(owner, DamageType.PHYSICAL) == 40
 
 
+def test_brace_incoming_protection_query_reports_state_without_consuming_it():
+    combat_state = CombatState()
+    owner = object()
+    opponent = object()
+
+    assert not combat_state.brace_incoming_protection_active(owner)
+
+    combat_state.activate_brace(owner)
+
+    assert combat_state.brace_incoming_protection_active(owner)
+    assert combat_state.brace_incoming_protection_active(owner)
+
+    combat_state.complete_accepted_action(opponent, opposing_combatants=(owner,))
+
+    assert not combat_state.brace_incoming_protection_active(owner)
+
+
 def test_brace_activation_does_not_expire_itself_through_complete_accepted_action():
     combat_state = CombatState()
     owner = object()
@@ -229,6 +253,22 @@ def test_heavy_payoff_does_not_consume_for_nonmatching_mechanics():
     )
 
 
+def test_brace_follow_up_query_is_non_consuming_and_mechanic_specific():
+    combat_state = CombatState()
+    owner = object()
+    combat_state.activate_brace(owner)
+
+    assert combat_state.brace_follow_up_damage_bonus_percent(owner, "basic_attack") == 0
+    assert combat_state.brace_follow_up_damage_bonus_percent(owner, None) == 0
+    assert combat_state.brace_follow_up_damage_bonus_percent(owner, "heavy_attack") == 30
+    assert combat_state.brace_follow_up_damage_bonus_percent(owner, "heavy_attack") == 30
+    assert (
+        combat_state.consume_brace_follow_up_damage_bonus_percent(owner, "heavy_attack")
+        == 30
+    )
+    assert combat_state.brace_follow_up_damage_bonus_percent(owner, "heavy_attack") == 0
+
+
 def test_heavy_payoff_returns_zero_when_no_active_payoff_exists():
     combat_state = CombatState()
     owner = object()
@@ -274,6 +314,10 @@ def test_brace_ownership_is_identity_based_and_unhashable_safe():
 
     combat_state.activate_brace(first)
 
+    assert combat_state.brace_incoming_protection_active(first)
+    assert not combat_state.brace_incoming_protection_active(second)
+    assert combat_state.brace_follow_up_damage_bonus_percent(first, "heavy_attack") == 30
+    assert combat_state.brace_follow_up_damage_bonus_percent(second, "heavy_attack") == 0
     assert combat_state.brace_incoming_reduction_percent(first, DamageType.PHYSICAL) == 40
     assert combat_state.brace_incoming_reduction_percent(second, DamageType.PHYSICAL) == 0
     assert (

--- a/tests/test_main_flow_player_state.py
+++ b/tests/test_main_flow_player_state.py
@@ -77,9 +77,10 @@ class FakeEnemyFactory:
 class FakeBattle:
     instances = []
 
-    def __init__(self, player_state, foe):
+    def __init__(self, player_state, foe, *, ui):
         self.player_state = player_state
         self.foe = foe
+        self.ui = ui
         self.__class__.instances.append(self)
 
     def run(self):
@@ -94,6 +95,13 @@ class FakeConsole:
     @staticmethod
     def clear_console():
         CALLS.append("clear_console")
+
+
+class FakeTerminalBattleUI:
+    instances = []
+
+    def __init__(self):
+        self.__class__.instances.append(self)
 
 
 CALLS = []
@@ -111,6 +119,7 @@ def reset_fakes():
     FakeEnemyFactory.calls = []
     FakeEnemyFactory.enemy_state = object()
     FakeBattle.instances = []
+    FakeTerminalBattleUI.instances = []
 
 
 def run_with_fakes(encounter):
@@ -124,6 +133,7 @@ def run_with_fakes(encounter):
     original_battle = main_loop.Battle
     original_create_enemy_state = main_loop.create_enemy_state
     original_console = main_loop.console
+    original_terminal_battle_ui = main_loop.TerminalBattleUI
 
     main_loop.PlayerState = FakePlayerState
     main_loop.GameState = FakeGameState
@@ -132,6 +142,7 @@ def run_with_fakes(encounter):
     main_loop.Battle = FakeBattle
     main_loop.create_enemy_state = FakeEnemyFactory.create_enemy_state
     main_loop.console = FakeConsole
+    main_loop.TerminalBattleUI = FakeTerminalBattleUI
 
     try:
         main_loop.main()
@@ -143,6 +154,7 @@ def run_with_fakes(encounter):
         main_loop.Battle = original_battle
         main_loop.create_enemy_state = original_create_enemy_state
         main_loop.console = original_console
+        main_loop.TerminalBattleUI = original_terminal_battle_ui
 
     return FakeEvents.selected_character, FakeStoryElements.instances[0], list(CALLS)
 
@@ -174,6 +186,8 @@ def test_battle_path_wraps_character_once_and_uses_wrapped_character():
     assert FakeBattle.instances[0].player_state is FakeGameState.instances[0].player_state
     assert FakeEnemyFactory.calls == [("goblin", 0)]
     assert FakeBattle.instances[0].foe is FakeEnemyFactory.enemy_state
+    assert len(FakeTerminalBattleUI.instances) == 1
+    assert FakeBattle.instances[0].ui is FakeTerminalBattleUI.instances[0]
     assert story.escaped_character is None
     assert story.battle_ending_character is selected_character
     assert story.battle_ending_winner == "player"

--- a/tests/test_move_contract.py
+++ b/tests/test_move_contract.py
@@ -10,6 +10,7 @@ from app.combat.move import (
     ScalingAttribute,
     TargetType,
 )
+from app.combat.move_presentation import MovePresentation, MoveRole
 
 
 def create_move(**overrides):
@@ -51,6 +52,38 @@ def test_move_is_immutable():
 
     with pytest.raises(FrozenInstanceError):
         setattr(move, "power", 99)
+
+
+def test_move_presentation_is_optional_immutable_and_inert():
+    assert create_move().presentation is None
+
+    presentation = MovePresentation(
+        role="heavy",
+        affinity_label="Fire",
+        static_summary="A concise summary.",
+    )
+    move = create_move(presentation=presentation)
+
+    assert move.presentation is presentation
+    assert presentation.role == MoveRole.HEAVY
+    assert presentation.affinity_label == "Fire"
+    assert presentation.static_summary == "A concise summary."
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(presentation, "role", MoveRole.NORMAL)
+
+
+def test_move_presentation_validation():
+    with pytest.raises(ValueError):
+        MovePresentation(role="unsupported")
+    with pytest.raises(ValueError):
+        MovePresentation(role=MoveRole.NORMAL, affinity_label="")
+    with pytest.raises(TypeError):
+        MovePresentation(role=MoveRole.NORMAL, affinity_label=1)
+    with pytest.raises(ValueError):
+        MovePresentation(role=MoveRole.NORMAL, static_summary="")
+    with pytest.raises(TypeError):
+        create_move(presentation={"role": "normal"})
 
 
 def test_resource_cost_validation():

--- a/tests/test_terminal_battle_ui.py
+++ b/tests/test_terminal_battle_ui.py
@@ -197,6 +197,70 @@ def test_render_uses_injected_output_and_semantic_log_values():
     assert "Choose an action:" in harness.lines
 
 
+def test_render_preserves_all_existing_move_result_categories_and_details():
+    entries = (
+        BattleLogEntry(
+            BattleEventType.DAMAGE,
+            actor_name="Ser Branoc",
+            action_name="Cut",
+            accepted=True,
+            hit=True,
+            amount=7,
+        ),
+        BattleLogEntry(
+            BattleEventType.HEALING,
+            actor_name="Ser Branoc",
+            action_name="Recover",
+            accepted=True,
+            hit=True,
+            amount=3,
+        ),
+        BattleLogEntry(
+            BattleEventType.MISS,
+            actor_name="Goblin",
+            action_name="Whiff",
+            accepted=True,
+            hit=False,
+        ),
+        BattleLogEntry(
+            BattleEventType.ACTION_REJECTED,
+            actor_name="Ser Branoc",
+            action_name="Blocked",
+            accepted=False,
+            hit=False,
+            reason="rejected",
+        ),
+        BattleLogEntry(
+            BattleEventType.UTILITY,
+            actor_name="Ser Branoc",
+            action_name="Brace",
+            accepted=True,
+            hit=True,
+            resource_spent=5,
+            statuses_applied=("ward",),
+        ),
+        BattleLogEntry(
+            BattleEventType.DEFEND,
+            actor_name="Ser Branoc",
+            action_name="Defend",
+            accepted=True,
+            hit=False,
+        ),
+    )
+    ui, harness = _ui(())
+
+    ui.render(_view(log_entries=entries))
+
+    assert "Ser Branoc used Cut. It dealt 7 damage." in harness.lines
+    assert "Ser Branoc used Recover. It restored 3 health." in harness.lines
+    assert "Goblin used Whiff, but missed." in harness.lines
+    assert "Ser Branoc used Blocked, but it failed: rejected." in harness.lines
+    assert "Ser Branoc used Brace. It resolved." in harness.lines
+    assert "Resource spent: 5." in harness.lines
+    assert "Statuses applied: ward." in harness.lines
+    assert "Ser Branoc used Defend." in harness.lines
+
+
 def test_adapter_retains_no_log_or_view_state_and_does_not_mutate_view():
     ui, _ = _ui(())
     view = _view()

--- a/tests/test_terminal_battle_ui.py
+++ b/tests/test_terminal_battle_ui.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 from app.presentation.battle_models import (
     ActionAvailabilityReason,
     ActionIntent,
@@ -87,7 +89,13 @@ def _ui(inputs):
         input_func=harness.input,
         output_func=harness.output,
         width_provider=lambda: 80,
+        ansi_enabled=False,
+        interactive=False,
     ), harness
+
+
+def _contains(harness, text):
+    return any(text in line for line in harness.lines)
 
 
 def test_action_numbers_and_aliases_return_semantic_actions():
@@ -192,13 +200,15 @@ def test_render_uses_injected_output_and_semantic_log_values():
 
     ui.render(_view(log_entries=(entry,)))
 
-    assert "Ser Branoc HP: 116/116" in harness.lines
-    assert "Goblin HP: 60/60" in harness.lines
-    assert (
-        "Ser Branoc used Ironwake Dismemberment. Critical hit! It dealt 21 damage."
-        in harness.lines
+    assert _contains(harness, "Ser Branoc")
+    assert _contains(harness, "HP 116/116")
+    assert _contains(harness, "Goblin")
+    assert _contains(harness, "HP 60/60")
+    assert _contains(
+        harness,
+        "Ser Branoc used Ironwake Dismemberment. Critical hit! It dealt 21 damage.",
     )
-    assert "Choose an action:" in harness.lines
+    assert _contains(harness, "Actions")
 
 
 def test_structured_move_menu_uses_readable_tags_and_wrapped_summaries():
@@ -247,7 +257,9 @@ def test_structured_move_menu_uses_readable_tags_and_wrapped_summaries():
     ui = TerminalBattleUI(
         input_func=harness.input,
         output_func=harness.output,
-        width_provider=lambda: 45,
+        width_provider=lambda: 60,
+        ansi_enabled=False,
+        interactive=False,
     )
 
     ui.render(
@@ -257,29 +269,28 @@ def test_structured_move_menu_uses_readable_tags_and_wrapped_summaries():
         )
     )
 
-    assert "1. Crestgrave Reaping [Normal]" in harness.lines
-    assert "2. Cinderlung Vesper [Fire Magic | 3 Mana]" in harness.lines
-    assert "3. Brace [Utility | 5 Mana]" in harness.lines
-    assert (
-        "4. Ironwake Dismemberment [Heavy | Empowered +30%]"
-        in harness.lines
+    assert _contains(harness, "1. Crestgrave Reaping [Normal]")
+    assert _contains(harness, "2. Cinderlung Vesper [Fire Magic | 3 Mana]")
+    assert _contains(harness, "3. Brace [Utility | 5 Mana]")
+    assert _contains(
+        harness,
+        "4. Ironwake Dismemberment [Heavy | Empowered +30%]",
     )
     assert not any("[none 0]" in line for line in harness.lines)
     assert all(
-        len(line) <= 45
+        len(line) <= 60
         for line in harness.lines
-        if line.startswith("   ")
     )
-    assert any(line.startswith("   Brace against") for line in harness.lines)
-    assert "0. Back" in harness.lines
+    assert _contains(harness, "Brace against")
+    assert _contains(harness, "0. Back")
 
 
 def test_back_is_rendered_only_during_move_phases_and_super_is_separate():
     ui, actions = _ui(())
     ui.render(_view())
 
-    assert "0. Back" not in actions.lines
-    assert not any(line.startswith("6. Super") for line in actions.lines)
+    assert not _contains(actions, "0. Back")
+    assert not _contains(actions, "6. Super")
 
     super_move = MoveOptionView(
         "Third Gate Obsequy",
@@ -299,9 +310,9 @@ def test_back_is_rendered_only_during_move_phases_and_super_is_separate():
         )
     )
 
-    assert "Choose a Super:" in super_menu.lines
-    assert "1. Third Gate Obsequy [Super | 100 Super]" in super_menu.lines
-    assert "0. Back" in super_menu.lines
+    assert _contains(super_menu, "Choose a Super:")
+    assert _contains(super_menu, "1. Third Gate Obsequy [Super | 100 Super]")
+    assert _contains(super_menu, "0. Back")
 
 
 def test_render_preserves_all_existing_move_result_categories_and_details():
@@ -354,18 +365,142 @@ def test_render_preserves_all_existing_move_result_categories_and_details():
             hit=False,
         ),
     )
-    ui, harness = _ui(())
+    ui, _ = _ui(())
 
-    ui.render(_view(log_entries=entries))
+    rendered_lines = tuple(
+        line
+        for entry in entries
+        for line in ui._log_lines(entry)
+    )
 
-    assert "Ser Branoc used Cut. It dealt 7 damage." in harness.lines
-    assert "Ser Branoc used Recover. It restored 3 health." in harness.lines
-    assert "Goblin used Whiff, but missed." in harness.lines
-    assert "Ser Branoc used Blocked, but it failed: rejected." in harness.lines
-    assert "Ser Branoc used Brace. It resolved." in harness.lines
-    assert "Resource spent: 5." in harness.lines
-    assert "Statuses applied: ward." in harness.lines
-    assert "Ser Branoc used Defend." in harness.lines
+    assert "Ser Branoc used Cut. It dealt 7 damage." in rendered_lines
+    assert "Ser Branoc used Recover. It restored 3 health." in rendered_lines
+    assert "Goblin used Whiff, but missed." in rendered_lines
+    assert "Ser Branoc used Blocked, but it failed: rejected." in rendered_lines
+    assert "Ser Branoc used Brace. It resolved." in rendered_lines
+    assert "Resource spent: 5." in rendered_lines
+    assert "Statuses applied: ward." in rendered_lines
+    assert "Ser Branoc used Defend." in rendered_lines
+
+
+def test_persistent_hud_preserves_sections_and_width_at_supported_sizes():
+    base_view = _view(
+        log_entries=(
+            BattleLogEntry(
+                BattleEventType.DAMAGE,
+                actor_name="Ser Branoc",
+                target_name="Goblin",
+                action_name="Crestgrave Reaping",
+                accepted=True,
+                hit=True,
+                amount=10,
+            ),
+            BattleLogEntry(
+                BattleEventType.MISS,
+                actor_name="Goblin",
+                action_name="slash",
+                accepted=True,
+                hit=False,
+            ),
+        ),
+    )
+    base_view = replace(
+        base_view,
+        player=replace(
+            base_view.player,
+            temporary_labels=("Defending", "Brace"),
+            defending=True,
+        ),
+        enemy=CombatantView("Goblin", 40, 60, 3, 5, 20, 100),
+    )
+
+    for width in (120, 80, 60):
+        harness = TerminalHarness()
+        ui = TerminalBattleUI(
+            input_func=harness.input,
+            output_func=harness.output,
+            width_provider=lambda width=width: width,
+            ansi_enabled=False,
+            interactive=False,
+        )
+
+        ui.render(base_view)
+        text = "\n".join(harness.lines)
+
+        assert all(len(line) <= width for line in harness.lines)
+        assert "Ser Branoc" in text and "Goblin" in text
+        assert "HP 116/116" in text and "HP 40/60" in text
+        assert "Mana 46/46" in text and "Mana 3/5" in text
+        assert "Super 20/100" in text
+        assert "State: Defending, Brace" in text
+        assert "VS" in text
+        assert text.index("Crestgrave Reaping") < text.index("Goblin used slash")
+        assert "1. Attack" in text
+        assert "2. Defend" in text
+        assert "3. Heal [Unavailable]" in text
+        assert "4. Items [Unavailable]" in text
+        assert "5. Escape [Unavailable]" in text
+        assert "4. Super" not in text
+        assert "SUPER [" in text and "0/100" in text
+        assert "\033[" not in text
+
+
+def test_ascii_and_linear_fallback_preserve_meaning_without_ansi():
+    harness = TerminalHarness()
+    ui = TerminalBattleUI(
+        input_func=harness.input,
+        output_func=harness.output,
+        width_provider=lambda: 50,
+        unicode_enabled=False,
+        ansi_enabled=False,
+        interactive=False,
+    )
+
+    ui.render(_view())
+    text = "\n".join(harness.lines)
+
+    assert all(len(line) <= 50 for line in harness.lines)
+    assert "STATUS" in text
+    assert "Ser Branoc" in text and "Goblin" in text
+    assert "ACTIONS" in text
+    assert "SUPER [" in text
+    assert "#" not in text
+    assert "-" in text
+    assert not any(character in text for character in "┌┐└┘├┤│─█░")
+    assert "\033[" not in text
+
+
+def test_super_meter_is_persistent_and_ready_text_matches_availability():
+    ui, normal = _ui(())
+    ui.render(_view())
+    normal_text = "\n".join(normal.lines)
+
+    assert "SUPER [" in normal_text
+    assert "0/100" in normal_text
+    assert "READY [S]" not in normal_text
+
+    ui, ready = _ui(())
+    ui.render(_view(super_ready=True))
+    ready_text = "\n".join(ready.lines)
+
+    assert "SUPER [" in ready_text
+    assert "100/100 READY [S]" in ready_text
+
+
+def test_interactive_ansi_mode_refreshes_without_retaining_state():
+    harness = TerminalHarness()
+    ui = TerminalBattleUI(
+        input_func=harness.input,
+        output_func=harness.output,
+        width_provider=lambda: 80,
+        ansi_enabled=True,
+        interactive=True,
+    )
+
+    ui.render(_view())
+
+    assert harness.lines[0].startswith("\033[2J\033[H")
+    assert sum("\033[2J\033[H" in line for line in harness.lines) == 1
 
 
 def test_adapter_retains_no_log_or_view_state_and_does_not_mutate_view():
@@ -376,4 +511,11 @@ def test_adapter_retains_no_log_or_view_state_and_does_not_mutate_view():
     ui.render(view)
 
     assert repr(view) == before
-    assert set(vars(ui)) == {"_input", "_output", "_width_provider"}
+    assert set(vars(ui)) == {
+        "_input",
+        "_output",
+        "_width_provider",
+        "_unicode_enabled",
+        "_ansi_enabled",
+        "_interactive",
+    }

--- a/tests/test_terminal_battle_ui.py
+++ b/tests/test_terminal_battle_ui.py
@@ -1,0 +1,208 @@
+from app.presentation.battle_models import (
+    ActionAvailabilityReason,
+    ActionIntent,
+    ActionOptionView,
+    BattleEventType,
+    BattleLogEntry,
+    BattleView,
+    CombatantView,
+    InteractionPhase,
+    MoveAvailabilityReason,
+    MoveOptionView,
+    SuperMeterView,
+)
+from app.ui.battle_ui import ChooseAction, ChooseMove, GoBack
+from app.ui.terminal_battle_ui import TerminalBattleUI
+
+
+class TerminalHarness:
+    def __init__(self, inputs=()):
+        self.inputs = iter(inputs)
+        self.lines = []
+
+    def input(self, prompt):
+        self.lines.append(prompt)
+        return next(self.inputs)
+
+    def output(self, message):
+        self.lines.append(message)
+
+
+def _view(
+    *,
+    phase=InteractionPhase.ACTIONS,
+    super_ready=False,
+    action_options=None,
+    move_options=(),
+    log_entries=(),
+):
+    player = CombatantView("Ser Branoc", 116, 116, 46, 46, 0, 100)
+    enemy = CombatantView("Goblin", 60, 60)
+    actions = action_options or (
+        ActionOptionView(ActionIntent.ATTACK, 1, "Attack", True),
+        ActionOptionView(ActionIntent.DEFEND, 2, "Defend", True),
+        ActionOptionView(
+            ActionIntent.HEAL,
+            3,
+            "Heal",
+            False,
+            ActionAvailabilityReason.NO_HEALING_MOVES,
+        ),
+        ActionOptionView(
+            ActionIntent.ITEMS,
+            4,
+            "Items",
+            False,
+            ActionAvailabilityReason.NOT_IMPLEMENTED,
+        ),
+        ActionOptionView(
+            ActionIntent.ESCAPE,
+            5,
+            "Escape",
+            False,
+            ActionAvailabilityReason.NOT_IMPLEMENTED,
+        ),
+    )
+    return BattleView(
+        interaction_phase=phase,
+        player=player,
+        enemy=enemy,
+        super_meter=SuperMeterView(
+            current=100 if super_ready else 0,
+            maximum=100,
+            fill_bps=10_000 if super_ready else 0,
+            ready=super_ready,
+            activation_key="S",
+            activation_offered=super_ready,
+        ),
+        action_options=actions,
+        move_options=move_options,
+        log_entries=log_entries,
+    )
+
+
+def _ui(inputs):
+    harness = TerminalHarness(inputs)
+    return TerminalBattleUI(input_func=harness.input, output_func=harness.output), harness
+
+
+def test_action_numbers_and_aliases_return_semantic_actions():
+    for raw, expected in (("1", ActionIntent.ATTACK), ("defend", ActionIntent.DEFEND)):
+        ui, _ = _ui((raw,))
+        assert ui.read_input(_view()) == ChooseAction(expected)
+
+
+def test_super_key_maps_to_semantic_action_from_any_phase():
+    ui, _ = _ui(("S",))
+
+    result = ui.read_input(
+        _view(phase=InteractionPhase.REGULAR_MOVES, super_ready=True)
+    )
+
+    assert result == ChooseAction(ActionIntent.SUPER)
+
+
+def test_move_number_maps_to_opaque_offered_key():
+    move = MoveOptionView(
+        "Ironwake Dismemberment",
+        4,
+        "Ironwake Dismemberment",
+        ("Heavy",),
+        "A crushing strike.",
+        None,
+        True,
+    )
+    ui, _ = _ui(("4",))
+
+    assert ui.read_input(
+        _view(phase=InteractionPhase.REGULAR_MOVES, move_options=(move,))
+    ) == ChooseMove("Ironwake Dismemberment")
+
+
+def test_back_is_returned_only_from_move_selection_phase():
+    ui, harness = _ui(("0", "attack"))
+
+    assert ui.read_input(_view()) == ChooseAction(ActionIntent.ATTACK)
+    assert "That is not a valid move. Please try again." in harness.lines
+
+    ui, _ = _ui(("0",))
+    assert isinstance(
+        ui.read_input(_view(phase=InteractionPhase.REGULAR_MOVES)),
+        GoBack,
+    )
+
+
+def test_malformed_and_disabled_choices_reprompt_locally():
+    ui, harness = _ui(("nonsense", "3", "2"))
+
+    assert ui.read_input(_view()) == ChooseAction(ActionIntent.DEFEND)
+    assert "Heal is not available." in harness.lines
+    assert harness.lines.count("That is not a valid move. Please try again.") == 2
+
+
+def test_disabled_move_is_not_returned():
+    disabled = MoveOptionView(
+        "Brace",
+        1,
+        "Brace",
+        ("Utility", "5 Mana"),
+        "Brace.",
+        "5 Mana",
+        False,
+        MoveAvailabilityReason.INSUFFICIENT_RESOURCE,
+    )
+    enabled = MoveOptionView(
+        "Crestgrave Reaping",
+        2,
+        "Crestgrave Reaping",
+        ("Normal",),
+        "Strike.",
+        None,
+        True,
+    )
+    ui, harness = _ui(("1", "2"))
+
+    result = ui.read_input(
+        _view(
+            phase=InteractionPhase.REGULAR_MOVES,
+            move_options=(disabled, enabled),
+        )
+    )
+
+    assert result == ChooseMove("Crestgrave Reaping")
+    assert "Brace is not available." in harness.lines
+
+
+def test_render_uses_injected_output_and_semantic_log_values():
+    entry = BattleLogEntry(
+        event_type=BattleEventType.DAMAGE,
+        actor_name="Ser Branoc",
+        target_name="Goblin",
+        action_name="Ironwake Dismemberment",
+        accepted=True,
+        hit=True,
+        amount=21,
+        critical=True,
+    )
+    ui, harness = _ui(())
+
+    ui.render(_view(log_entries=(entry,)))
+
+    assert "Ser Branoc HP: 116/116" in harness.lines
+    assert "Goblin HP: 60/60" in harness.lines
+    assert (
+        "Ser Branoc used Ironwake Dismemberment. Critical hit! It dealt 21 damage."
+        in harness.lines
+    )
+    assert "Choose an action:" in harness.lines
+
+
+def test_adapter_retains_no_log_or_view_state_and_does_not_mutate_view():
+    ui, _ = _ui(())
+    view = _view()
+    before = repr(view)
+
+    ui.render(view)
+
+    assert repr(view) == before
+    assert set(vars(ui)) == {"_input", "_output"}

--- a/tests/test_terminal_battle_ui.py
+++ b/tests/test_terminal_battle_ui.py
@@ -83,7 +83,11 @@ def _view(
 
 def _ui(inputs):
     harness = TerminalHarness(inputs)
-    return TerminalBattleUI(input_func=harness.input, output_func=harness.output), harness
+    return TerminalBattleUI(
+        input_func=harness.input,
+        output_func=harness.output,
+        width_provider=lambda: 80,
+    ), harness
 
 
 def test_action_numbers_and_aliases_return_semantic_actions():
@@ -197,6 +201,109 @@ def test_render_uses_injected_output_and_semantic_log_values():
     assert "Choose an action:" in harness.lines
 
 
+def test_structured_move_menu_uses_readable_tags_and_wrapped_summaries():
+    moves = (
+        MoveOptionView(
+            "Crestgrave Reaping",
+            1,
+            "Crestgrave Reaping",
+            ("Normal",),
+            "Sunder-Spire tears through the target.",
+            None,
+            True,
+        ),
+        MoveOptionView(
+            "Cinderlung Vesper",
+            2,
+            "Cinderlung Vesper",
+            ("Fire Magic", "3 Mana"),
+            "A black war-breath erupts forward.",
+            "3 Mana",
+            True,
+        ),
+        MoveOptionView(
+            "Brace",
+            3,
+            "Brace",
+            ("Utility", "5 Mana"),
+            (
+                "Brace against the next enemy action, reducing physical damage "
+                "by 40%, and empower your next Heavy attack by 30%."
+            ),
+            "5 Mana",
+            True,
+        ),
+        MoveOptionView(
+            "Ironwake Dismemberment",
+            4,
+            "Ironwake Dismemberment",
+            ("Heavy", "Empowered +30%"),
+            "A crushing Sunder-Spire strike.",
+            None,
+            True,
+        ),
+    )
+    harness = TerminalHarness()
+    ui = TerminalBattleUI(
+        input_func=harness.input,
+        output_func=harness.output,
+        width_provider=lambda: 45,
+    )
+
+    ui.render(
+        _view(
+            phase=InteractionPhase.REGULAR_MOVES,
+            move_options=moves,
+        )
+    )
+
+    assert "1. Crestgrave Reaping [Normal]" in harness.lines
+    assert "2. Cinderlung Vesper [Fire Magic | 3 Mana]" in harness.lines
+    assert "3. Brace [Utility | 5 Mana]" in harness.lines
+    assert (
+        "4. Ironwake Dismemberment [Heavy | Empowered +30%]"
+        in harness.lines
+    )
+    assert not any("[none 0]" in line for line in harness.lines)
+    assert all(
+        len(line) <= 45
+        for line in harness.lines
+        if line.startswith("   ")
+    )
+    assert any(line.startswith("   Brace against") for line in harness.lines)
+    assert "0. Back" in harness.lines
+
+
+def test_back_is_rendered_only_during_move_phases_and_super_is_separate():
+    ui, actions = _ui(())
+    ui.render(_view())
+
+    assert "0. Back" not in actions.lines
+    assert not any(line.startswith("6. Super") for line in actions.lines)
+
+    super_move = MoveOptionView(
+        "Third Gate Obsequy",
+        1,
+        "Third Gate Obsequy",
+        ("Super", "100 Super"),
+        "A forbidden gate manifests.",
+        "100 Super",
+        True,
+    )
+    ui, super_menu = _ui(())
+    ui.render(
+        _view(
+            phase=InteractionPhase.SUPER_MOVES,
+            super_ready=True,
+            move_options=(super_move,),
+        )
+    )
+
+    assert "Choose a Super:" in super_menu.lines
+    assert "1. Third Gate Obsequy [Super | 100 Super]" in super_menu.lines
+    assert "0. Back" in super_menu.lines
+
+
 def test_render_preserves_all_existing_move_result_categories_and_details():
     entries = (
         BattleLogEntry(
@@ -269,4 +376,4 @@ def test_adapter_retains_no_log_or_view_state_and_does_not_mutate_view():
     ui.render(view)
 
     assert repr(view) == before
-    assert set(vars(ui)) == {"_input", "_output"}
+    assert set(vars(ui)) == {"_input", "_output", "_width_provider"}


### PR DESCRIPTION
## Summary

Extract terminal presentation and semantic input from Battle while preserving combat ownership and lifecycle behavior.

## Included

- UI-0 through UI-5 presentation separation
- immutable BattleView models and pure BattlePresenter
- semantic BattleInput and offered-intent validation
- stateless TerminalBattleUI with HUD, log, move presentation, and persistent Super meter
- Brace dynamic presentation without consuming combat state
- all-four-Drifter resolver compatibility and Goblin vertical-slice hardening
- UI-H removal of obsolete private Battle menu bridges

## Validation

- 383 pytest tests passed
- compileall passed
- git diff --check passed
- Branoc, Azhvielle, Zhaivra, and Joruun completed deterministic Goblin playthroughs

This PR preserves the reviewed commit history and is intended for a normal merge commit into v0.2.9.